### PR TITLE
Fix: spring-boot-starter-web 의존성 추가

### DIFF
--- a/eureka/build.gradle
+++ b/eureka/build.gradle
@@ -22,6 +22,7 @@ ext {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
This PR closes #6.

`spring-boot-starter-web` 의존성을 추가하였습니다.
이유는 issue에 기술하였습니다.





