### PR TITLE
Feat: 상품 API의 CRUD, Search 를 작성, Test 코드 작성

### DIFF
--- a/company/src/main/java/com/sparta/ch4/delivery/company/application/dto/CompanyDto.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/application/dto/CompanyDto.java
@@ -20,7 +20,7 @@ public record CompanyDto(
         String updatedBy,
         LocalDateTime deletedAt,
         String deletedBy,
-        boolean isDeleted
+        Boolean isDeleted
 ) {
 
     public static CompanyDto from(Company entity) {

--- a/company/src/main/java/com/sparta/ch4/delivery/company/application/dto/ProductDto.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/application/dto/ProductDto.java
@@ -15,6 +15,8 @@ public record ProductDto(
         String companyName,
         CompanyType companyType,
         String companyAddress,
+        UUID companyHubId,
+        LocalDateTime companyCreatedAt,
         UUID hubId,
         String name,
         Integer quantity,
@@ -34,6 +36,8 @@ public record ProductDto(
                 .companyName(entity.getCompany().getName())
                 .companyType(entity.getCompany().getType())
                 .companyAddress(entity.getCompany().getAddress())
+                .companyHubId(entity.getCompany().getHubId())
+                .companyCreatedAt(entity.getCompany().getCreatedAt())
                 .hubId(entity.getHubId())
                 .name(entity.getName())
                 .quantity(entity.getQuantity())

--- a/company/src/main/java/com/sparta/ch4/delivery/company/application/service/ProductService.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/application/service/ProductService.java
@@ -1,8 +1,13 @@
 package com.sparta.ch4.delivery.company.application.service;
 
+import com.sparta.ch4.delivery.company.application.dto.CompanyDto;
 import com.sparta.ch4.delivery.company.application.dto.ProductDto;
 import com.sparta.ch4.delivery.company.domain.service.ProductDomainService;
+import com.sparta.ch4.delivery.company.domain.type.CompanySearchType;
+import com.sparta.ch4.delivery.company.domain.type.ProductSearchType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +20,7 @@ public class ProductService {
     private final ProductDomainService productDomainService;
 
 
+    // TODO : 상품 관리 허브가 존재하는 지 확인
     @Transactional
     public ProductDto createProduct(ProductDto productDto) {
         return productDomainService.createProduct(productDto);
@@ -25,4 +31,19 @@ public class ProductService {
         return productDomainService.getProductById(productId);
     }
 
+    @Transactional(readOnly = true)
+    public Page<ProductDto> getAllProducts(UUID companyId, UUID hubId, ProductSearchType searchType, String searchValue, Pageable pageable) {
+        return productDomainService.getAllProducts(companyId, hubId, searchType, searchValue, pageable);
+    }
+
+    // TODO : 상품 관리 허브가 존재하는 지 확인
+    @Transactional
+    public ProductDto updateProduct(UUID productId, ProductDto dto) {
+        return productDomainService.updateProduct(productId, dto);
+    }
+
+    @Transactional
+    public void deleteProduct(UUID productId, String userId) {
+        productDomainService.deleteProduct(productId, userId);
+    }
 }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/domain/repository/ProductRepositoryCustom.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/domain/repository/ProductRepositoryCustom.java
@@ -1,4 +1,13 @@
 package com.sparta.ch4.delivery.company.domain.repository;
 
+import com.sparta.ch4.delivery.company.domain.model.Product;
+import com.sparta.ch4.delivery.company.domain.type.ProductSearchType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
 public interface ProductRepositoryCustom {
+
+    Page<Product> searchProducts(UUID companyId, UUID hubId, ProductSearchType searchType, String searchValue, Pageable pageable);
 }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/domain/service/CompanyDomainService.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/domain/service/CompanyDomainService.java
@@ -46,6 +46,7 @@ public class CompanyDomainService {
         company.setName(dto.name());
         company.setType(dto.type());
         company.setAddress(dto.address());
+        company.setUpdatedBy(dto.updatedBy());
         // 저장
         return CompanyDto.from(companyRepository.save(company));
     }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/domain/service/ProductDomainService.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/domain/service/ProductDomainService.java
@@ -2,15 +2,20 @@ package com.sparta.ch4.delivery.company.domain.service;
 
 import com.sparta.ch4.delivery.company.application.dto.ProductDto;
 import com.sparta.ch4.delivery.company.domain.model.Company;
+import com.sparta.ch4.delivery.company.domain.model.Product;
 import com.sparta.ch4.delivery.company.domain.repository.CompanyRepository;
 import com.sparta.ch4.delivery.company.domain.repository.ProductRepository;
+import com.sparta.ch4.delivery.company.domain.type.ProductSearchType;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+//TODO : 에러 내용 정의
 @RequiredArgsConstructor
 @Service
 public class ProductDomainService {
@@ -18,7 +23,6 @@ public class ProductDomainService {
     private final ProductRepository productRepository;
     private final CompanyRepository companyRepository;
 
-    //TODO : 에러 내용 정의
     public ProductDto createProduct(ProductDto productDto) {
         Company company = companyRepository.findById(productDto.companyId()).orElseThrow(
                 () -> new EntityNotFoundException("ID 에 해당하는 업체를 찾을 수 없습니다.")
@@ -27,11 +31,45 @@ public class ProductDomainService {
         return ProductDto.from(productRepository.save(productDto.toEntity(company)));
     }
 
-    //TODO : 에러 내용 정의
+
     public ProductDto getProductById(UUID productId) {
         return productRepository.findById(productId).map(ProductDto::from).orElseThrow(
                 () -> new EntityNotFoundException("ID 에 해당하는 상품을 찾을 수 없습니다.")
         );
     }
 
+    public Page<ProductDto> getAllProducts(UUID companyId, UUID hubId, ProductSearchType searchType, String searchValue, Pageable pageable) {
+        return productRepository.searchProducts(companyId, hubId, searchType, searchValue, pageable).map(ProductDto::from);
+    }
+
+    public ProductDto updateProduct(UUID productId, ProductDto productDto) {
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new EntityNotFoundException("ID 에 해당하는 상품을 찾을 수 없습니다.")
+        );
+
+        // companyId 가 업데이트 될 때 존재하는 업체인지 확인
+        if (!productDto.companyId().equals(product.getCompany().getId())) {
+            Company company = companyRepository.findById(productDto.companyId()).orElseThrow(
+                    () -> new EntityNotFoundException("ID 에 해당하는 업체를 찾을 수 없습니다.")
+            );
+            //있다면 업데이트
+            product.setCompany(company);
+        }
+        //다른 필드 업데이트
+        product.setName(productDto.name());
+        product.setQuantity(productDto.quantity());
+        product.setHubId(productDto.hubId());
+
+        return ProductDto.from(productRepository.save(product));
+    }
+
+    public void deleteProduct(UUID productId, String userId) {
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new EntityNotFoundException("ID 에 해당하는 상품을 찾을 수 없습니다.")
+        );
+        // Soft delete
+        product.setDeletedAt(LocalDateTime.now());
+        product.setDeletedBy(userId);
+        product.setIsDeleted(true);
+    }
 }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/domain/type/ProductSearchType.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/domain/type/ProductSearchType.java
@@ -1,0 +1,6 @@
+package com.sparta.ch4.delivery.company.domain.type;
+
+public enum ProductSearchType {
+    COMPANY_NAME, // 관리 업체 이름
+    NAME, // 상품 이름
+}

--- a/company/src/main/java/com/sparta/ch4/delivery/company/infrastructure/repository/ProductRepositoryCustomImpl.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/infrastructure/repository/ProductRepositoryCustomImpl.java
@@ -1,12 +1,82 @@
 package com.sparta.ch4.delivery.company.infrastructure.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.ch4.delivery.company.domain.model.Product;
+import com.sparta.ch4.delivery.company.domain.model.QCompany;
+import com.sparta.ch4.delivery.company.domain.model.QProduct;
 import com.sparta.ch4.delivery.company.domain.repository.ProductRepositoryCustom;
+import com.sparta.ch4.delivery.company.domain.type.ProductSearchType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    QProduct product = QProduct.product;
+    QCompany company = QCompany.company;
+
+    @Override
+    public Page<Product> searchProducts(UUID companyId, UUID hubId, ProductSearchType searchType, String searchValue, Pageable pageable) {
+        List<Product> products = queryFactory
+                .selectFrom(product).distinct()
+                .leftJoin(product.company, company) // 상품은 연관된 업체와 연관지어 검색
+                .where(
+                        getSearchPredicate(searchType, searchValue)
+                        , filterByCompanyId(companyId)
+                        , filterByHubId(hubId)
+                        , isDeletedCondition()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory.select(product.count())
+                .from(product).distinct()
+                .leftJoin(product.company, company)
+                .where(
+                        getSearchPredicate(searchType, searchValue)
+                        , filterByCompanyId(companyId)
+                        , filterByHubId(hubId)
+                        , isDeletedCondition()
+                )
+                .fetchOne();
+
+        assert total != null;
+
+        return new PageImpl<>(products, pageable, total);
+    }
+
+
+    private BooleanExpression getSearchPredicate(ProductSearchType searchType, String searchValue) {
+        if (searchValue == null || searchType == null) {
+            return null;
+        }
+        return switch (searchType) {
+            case NAME -> product.name.containsIgnoreCase(searchValue);  // 상품 이름 검색
+            case COMPANY_NAME -> product.company.name.containsIgnoreCase(searchValue);  // 회사 이름 검색
+        };
+    }
+
+    private BooleanExpression isDeletedCondition() {
+        return product.isDeleted.eq(false);
+    }
+
+    // 관리 업체 필터링
+    private BooleanExpression filterByCompanyId(UUID companyId) {
+        return companyId != null ? product.company.id.eq(companyId) : null;
+    }
+
+    // 관리 허브 필터링
+    private BooleanExpression filterByHubId(UUID hubId) {
+        return hubId != null ? product.hubId.eq(hubId) : null;
+    }
 
 }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/presentation/controller/CompanyController.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/presentation/controller/CompanyController.java
@@ -80,6 +80,6 @@ public class CompanyController {
             @RequestHeader("X-UserId") String userId
     ) {
         companyService.deleteCompany(companyId, userId);
-        return CommonResponse.success("음식점 삭제 성공");
+        return CommonResponse.success("업체 삭제 성공");
     }
 }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/presentation/controller/CompanyController.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/presentation/controller/CompanyController.java
@@ -9,7 +9,6 @@ import com.sparta.ch4.delivery.company.presentation.response.CommonResponse;
 import com.sparta.ch4.delivery.company.presentation.response.CompanyResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.annotations.Parameter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -37,7 +36,7 @@ public class CompanyController {
         );
     }
 
-    @GetMapping()
+    @GetMapping
     public CommonResponse<Page<CompanyResponse>> getCompanies(
             @RequestParam(required = false, name = "searchType") CompanySearchType searchType,
             @RequestParam(required = false, name = "searchValue") String searchValue,
@@ -75,11 +74,10 @@ public class CompanyController {
     // Header 에 들어온 userId 로 deletedBy 설정
     @DeleteMapping("/{companyId}")
     @ResponseStatus(code = HttpStatus.NO_CONTENT)
-    public CommonResponse<Void> delete(
+    public void delete(
             @PathVariable(name = "companyId") UUID companyId,
             @RequestHeader("X-UserId") String userId
     ) {
         companyService.deleteCompany(companyId, userId);
-        return CommonResponse.success("업체 삭제 성공");
     }
 }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/presentation/controller/ProductController.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/presentation/controller/ProductController.java
@@ -2,14 +2,10 @@ package com.sparta.ch4.delivery.company.presentation.controller;
 
 
 import com.sparta.ch4.delivery.company.application.service.ProductService;
-import com.sparta.ch4.delivery.company.domain.type.CompanySearchType;
 import com.sparta.ch4.delivery.company.domain.type.ProductSearchType;
-import com.sparta.ch4.delivery.company.presentation.request.CompanyCreateRequest;
-import com.sparta.ch4.delivery.company.presentation.request.CompanyUpdateRequest;
 import com.sparta.ch4.delivery.company.presentation.request.ProductCreateRequest;
 import com.sparta.ch4.delivery.company.presentation.request.ProductUpdateRequest;
 import com.sparta.ch4.delivery.company.presentation.response.CommonResponse;
-import com.sparta.ch4.delivery.company.presentation.response.CompanyResponse;
 import com.sparta.ch4.delivery.company.presentation.response.ProductResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +35,7 @@ public class ProductController {
         );
     }
 
-    @GetMapping()
+    @GetMapping
     public CommonResponse<Page<ProductResponse>> getProducts(
             @RequestParam(required = false, name = "companyId") UUID companyId,
             @RequestParam(required = false, name = "hubId") UUID hubId,
@@ -78,11 +74,10 @@ public class ProductController {
     // Header 에 들어온 userId 로 deletedBy 설정
     @DeleteMapping("/{productId}")
     @ResponseStatus(code = HttpStatus.NO_CONTENT)
-    public CommonResponse<Void> delete(
+    public void delete(
             @PathVariable(name = "productId") UUID productId,
             @RequestHeader("X-UserId") String userId
     ) {
         productService.deleteProduct(productId, userId);
-        return CommonResponse.success("상품 삭제 성공");
     }
 }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/presentation/controller/ProductController.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/presentation/controller/ProductController.java
@@ -2,12 +2,22 @@ package com.sparta.ch4.delivery.company.presentation.controller;
 
 
 import com.sparta.ch4.delivery.company.application.service.ProductService;
+import com.sparta.ch4.delivery.company.domain.type.CompanySearchType;
+import com.sparta.ch4.delivery.company.domain.type.ProductSearchType;
 import com.sparta.ch4.delivery.company.presentation.request.CompanyCreateRequest;
+import com.sparta.ch4.delivery.company.presentation.request.CompanyUpdateRequest;
 import com.sparta.ch4.delivery.company.presentation.request.ProductCreateRequest;
+import com.sparta.ch4.delivery.company.presentation.request.ProductUpdateRequest;
 import com.sparta.ch4.delivery.company.presentation.response.CommonResponse;
 import com.sparta.ch4.delivery.company.presentation.response.CompanyResponse;
 import com.sparta.ch4.delivery.company.presentation.response.ProductResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -20,8 +30,8 @@ public class ProductController {
 
     // Header 에 들어온 userId 로 createdBy 설정
     @PostMapping
-    public CommonResponse<ProductResponse> createCompany(
-            @RequestBody ProductCreateRequest request,
+    public CommonResponse<ProductResponse> createProduct(
+            @Valid @RequestBody ProductCreateRequest request,
             @RequestHeader("X-UserId") String userId
     ) {
         return CommonResponse.success(
@@ -29,12 +39,50 @@ public class ProductController {
         );
     }
 
-    @GetMapping("/{companyId}")
-    public CommonResponse<ProductResponse> getCompany(
-            @PathVariable(name = "companyId") UUID companyId
+    @GetMapping()
+    public CommonResponse<Page<ProductResponse>> getProducts(
+            @RequestParam(required = false, name = "companyId") UUID companyId,
+            @RequestParam(required = false, name = "hubId") UUID hubId,
+            @RequestParam(required = false, name = "searchType") ProductSearchType searchType,
+            @RequestParam(required = false, name = "searchValue") String searchValue,
+            @PageableDefault(
+                    size = 10, sort = {"createdAt", "updatedAt"}, direction = Sort.Direction.DESC
+            ) Pageable pageable
     ) {
         return CommonResponse.success(
-                ProductResponse.from(productService.getProductById(companyId))
+                productService.getAllProducts(companyId, hubId, searchType, searchValue, pageable).map(ProductResponse::from)
         );
+    }
+
+    @GetMapping("/{productId}")
+    public CommonResponse<ProductResponse> getProduct(
+            @PathVariable(name = "productId") UUID productId
+    ) {
+        return CommonResponse.success(
+                ProductResponse.from(productService.getProductById(productId))
+        );
+    }
+
+    // Header 에 들어온 userId 로 updatedBy 설정
+    @PutMapping("/{productId}")
+    public CommonResponse<ProductResponse> updateProduct(
+            @PathVariable(name = "productId") UUID productId,
+            @Valid @RequestBody ProductUpdateRequest request,
+            @RequestHeader("X-UserId") String userId
+    ) {
+        return CommonResponse.success(
+                ProductResponse.from(productService.updateProduct(productId, request.toDto(userId)))
+        );
+    }
+
+    // Header 에 들어온 userId 로 deletedBy 설정
+    @DeleteMapping("/{productId}")
+    @ResponseStatus(code = HttpStatus.NO_CONTENT)
+    public CommonResponse<Void> delete(
+            @PathVariable(name = "productId") UUID productId,
+            @RequestHeader("X-UserId") String userId
+    ) {
+        productService.deleteProduct(productId, userId);
+        return CommonResponse.success("상품 삭제 성공");
     }
 }

--- a/company/src/main/java/com/sparta/ch4/delivery/company/presentation/request/ProductUpdateRequest.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/presentation/request/ProductUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.sparta.ch4.delivery.company.presentation.request;
+
+import com.sparta.ch4.delivery.company.application.dto.ProductDto;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record ProductUpdateRequest(
+        @NotNull(message = "업체 ID 는 비어있을 수 없습니다.")
+        UUID companyId,
+        @NotNull(message = "허브 ID 는 비어있을 수 없습니다.")
+        UUID hubId,
+        @NotBlank(message = "상품 이름은 비어있을 수 없습니다.")
+        String name,
+        @Min(value = 0, message = "상품 수량은 0 이상이어야 합니다.")
+        @NotNull(message = "상품 수량은 비어있을 수 없습니다.")
+        Integer quantity
+) {
+
+    public ProductDto toDto(String userId) {
+        return ProductDto.builder()
+                .companyId(companyId)
+                .hubId(hubId)
+                .name(name)
+                .quantity(quantity)
+                .updatedBy(userId)
+                .build();
+    }
+}

--- a/company/src/main/java/com/sparta/ch4/delivery/company/presentation/response/ProductResponse.java
+++ b/company/src/main/java/com/sparta/ch4/delivery/company/presentation/response/ProductResponse.java
@@ -1,5 +1,6 @@
 package com.sparta.ch4.delivery.company.presentation.response;
 
+import com.sparta.ch4.delivery.company.application.dto.CompanyDto;
 import com.sparta.ch4.delivery.company.application.dto.ProductDto;
 import lombok.Builder;
 
@@ -9,7 +10,7 @@ import java.util.UUID;
 @Builder
 public record ProductResponse(
         UUID id,
-        UUID companyId,
+        CompanyResponse company,
         UUID hubId,
         String name,
         Integer quantity,
@@ -20,7 +21,14 @@ public record ProductResponse(
     public static ProductResponse from(ProductDto dto) {
         return ProductResponse.builder()
                 .id(dto.id())
-                .companyId(dto.companyId())
+                .company(CompanyResponse.from(CompanyDto.builder()
+                        .id(dto.companyId())
+                        .hubId(dto.companyHubId())
+                        .type(dto.companyType())
+                        .name(dto.companyName())
+                        .address(dto.companyAddress())
+                        .createdAt(dto.companyCreatedAt())
+                        .build()))
                 .hubId(dto.hubId())
                 .name(dto.name())
                 .quantity(dto.quantity())

--- a/company/src/test/java/com/sparta/ch4/delivery/company/application/service/ProductServiceTest.java
+++ b/company/src/test/java/com/sparta/ch4/delivery/company/application/service/ProductServiceTest.java
@@ -1,0 +1,122 @@
+package com.sparta.ch4.delivery.company.application.service;
+
+import com.sparta.ch4.delivery.company.application.dto.ProductDto;
+import com.sparta.ch4.delivery.company.domain.service.ProductDomainService;
+import com.sparta.ch4.delivery.company.domain.type.ProductSearchType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @InjectMocks
+    private ProductService productService;
+
+    @Mock
+    private ProductDomainService productDomainService;
+
+    private ProductDto productDto;
+    private UUID productId;
+    private UUID companyId;
+    private UUID hubId;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        productId = UUID.randomUUID();
+        companyId = UUID.randomUUID();
+        hubId = UUID.randomUUID();
+        pageable = Pageable.ofSize(10);
+
+        productDto = ProductDto.builder()
+                .id(productId)
+                .companyId(companyId)
+                .hubId(hubId)
+                .name("Test Product")
+                .quantity(100)
+                .build();
+    }
+
+    @Test
+    void testCreateProduct() {
+        // Arrange
+        when(productDomainService.createProduct(any(ProductDto.class))).thenReturn(productDto);
+
+        // Act
+        ProductDto result = productService.createProduct(productDto);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(productDto, result);
+        verify(productDomainService, times(1)).createProduct(productDto);
+    }
+
+    @Test
+    void testGetProductById() {
+        // Arrange
+        when(productDomainService.getProductById(any(UUID.class))).thenReturn(productDto);
+
+        // Act
+        ProductDto result = productService.getProductById(productId);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(productDto, result);
+        verify(productDomainService, times(1)).getProductById(productId);
+    }
+
+    @Test
+    void testGetAllProducts() {
+        // Arrange
+        Page<ProductDto> productPage = new PageImpl<>(Collections.singletonList(productDto));
+        when(productDomainService.getAllProducts(any(UUID.class), any(UUID.class), any(ProductSearchType.class), anyString(), any(Pageable.class)))
+                .thenReturn(productPage);
+
+        // Act
+        Page<ProductDto> result = productService.getAllProducts(companyId, hubId, ProductSearchType.NAME, "Test", pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(productDomainService, times(1))
+                .getAllProducts(companyId, hubId, ProductSearchType.NAME, "Test", pageable);
+    }
+
+    @Test
+    void testUpdateProduct() {
+        // Arrange
+        when(productDomainService.updateProduct(any(UUID.class), any(ProductDto.class))).thenReturn(productDto);
+
+        // Act
+        ProductDto result = productService.updateProduct(productId, productDto);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(productDto, result);
+        verify(productDomainService, times(1)).updateProduct(productId, productDto);
+    }
+
+    @Test
+    void testDeleteProduct() {
+        // Act
+        productService.deleteProduct(productId, "testUser");
+
+        // Assert
+        verify(productDomainService, times(1)).deleteProduct(productId, "testUser");
+    }
+}

--- a/company/src/test/java/com/sparta/ch4/delivery/company/presentation/controller/ProductControllerTest.java
+++ b/company/src/test/java/com/sparta/ch4/delivery/company/presentation/controller/ProductControllerTest.java
@@ -1,0 +1,117 @@
+package com.sparta.ch4.delivery.company.presentation.controller;
+
+import com.sparta.ch4.delivery.company.application.dto.ProductDto;
+import com.sparta.ch4.delivery.company.application.service.ProductService;
+import com.sparta.ch4.delivery.company.domain.type.CompanyType;
+import com.sparta.ch4.delivery.company.domain.type.ProductSearchType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductControllerTest {
+
+    @Mock
+    private ProductService productService;
+
+    @InjectMocks
+    private ProductController productController;
+
+    private MockMvc mockMvc;
+
+    private ProductDto productDto;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(productController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver()) // Pageable 처리
+                .build();
+
+        productDto = ProductDto.builder()
+                .id(UUID.randomUUID())
+                .companyId(UUID.randomUUID())
+                .companyName("Test Company")
+                .companyType(CompanyType.RECIPIENT)
+                .companyAddress("Test Address")
+                .companyHubId(UUID.randomUUID())
+                .companyCreatedAt(LocalDateTime.now())
+                .hubId(UUID.randomUUID())
+                .name("Test Product")
+                .quantity(100)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    public void getProduct_returnsProductResponse() throws Exception {
+        UUID productId = UUID.randomUUID();
+        when(productService.getProductById(productId)).thenReturn(productDto);
+
+        mockMvc.perform(get("/api/products/{productId}", productId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.data.id").value(productDto.id().toString()))
+                .andExpect(jsonPath("$.data.company.id").value(productDto.companyId().toString()))
+                .andExpect(jsonPath("$.data.company.name").value(productDto.companyName()))
+                .andExpect(jsonPath("$.data.name").value(productDto.name()))
+                .andExpect(jsonPath("$.data.quantity").value(productDto.quantity()))
+                .andExpect(jsonPath("$.data.createdAt").exists());
+    }
+
+    @Test
+    public void getAllProducts_searchByName_returnsProductResponses() throws Exception {
+        ProductSearchType searchType = ProductSearchType.NAME;
+        String searchValue = "Test"; // -> Test Product
+
+        List<ProductDto> productDtos = List.of(productDto);
+        Page<ProductDto> productDtoPage = new PageImpl<>(productDtos,Pageable.ofSize(10), productDtos.size());
+
+        when(productService.getAllProducts(eq(null),eq(null), eq(searchType), eq(searchValue), any(Pageable.class)))
+                .thenReturn(productDtoPage);
+
+        mockMvc.perform(get("/api/products")
+                        .param("searchType", searchType.name())
+                        .param("searchValue", searchValue)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.data.content[0].id").value(productDto.id().toString()))
+                .andExpect(jsonPath("$.data.content[0].company.id").value(productDto.companyId().toString()))
+                .andExpect(jsonPath("$.data.content[0].company.name").value(productDto.companyName()))
+                .andExpect(jsonPath("$.data.content[0].name").value(productDto.name()))
+                .andExpect(jsonPath("$.data.content[0].quantity").value(productDto.quantity()))
+                .andExpect(jsonPath("$.data.content[0].createdAt").exists())
+                .andExpect(jsonPath("$.data.totalElements").value(productDtos.size()))
+                .andExpect(jsonPath("$.data.totalPages").value(1));
+    }
+
+}


### PR DESCRIPTION
## Feat
- CRUD, Search API 를 명세에 맞춰 개발함.
- QueryDsl 을 사용하여 조건적 검색을 구현
- Update, Delete 시 `updatedBy`, `deletedBy` 를 수동으로 저장
- Service 테스트 코드 작성 : CRUD 테스트
- Controller 테스트 코드 작성 : 단건 조회, 전체 조회(검색) 결과 필드 검증

## fix
- product dto, response 필드 수정
- company 관련 코드 잘못 작성한 부분 수정

### Notice
- API 명세에 전체 조회 API 의 spec 수정 : 쿼리 파라미터에 SearchType 추가
- 전체 조회(검색) 시, `hub_id` 와 `company_id` 는 추가적인 필터링 조건으로 들어갈 여지가 있기에, SearchType 안이 아닌 query parameter 를 통해 추가적으로 받을 수 있게 하였음. 


TODO
- 검색 시 hub_id 와 company_id 가 같이 들어올 경우에 대한 추가적인 검증 로직이 필요함
- queryDsl 을 통해 search 쿼리 작성 시 필요한 필드만 select 하는 쿼리로 리팩토링 할 여지가 있음. ( 학습 후 적용할 예정 )

This PR closes #15 
