### PR TITLE
Feat: 사용자 CRUD Api 구현

### DIFF
--- a/user/build.gradle
+++ b/user/build.gradle
@@ -31,6 +31,8 @@ ext {
 dependencies {
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/user/src/main/java/com/sparta/ch4/delivery/user/UserApplication.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/UserApplication.java
@@ -3,9 +3,13 @@ package com.sparta.ch4.delivery.user;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableSpringDataWebSupport(
+		pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO
+)
 public class UserApplication {
 
 	public static void main(String[] args) {

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/RegisterDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/RegisterDto.java
@@ -1,0 +1,31 @@
+package com.sparta.ch4.delivery.user.application.dto;
+
+import com.sparta.ch4.delivery.user.domain.model.User;
+import com.sparta.ch4.delivery.user.domain.type.UserRole;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record RegisterDto(
+        UUID hubId,
+        UUID companyId,
+        String username,
+        String email,
+        String password,
+        UserRole role,
+        Boolean isDeleted
+) {
+
+    public User toEntity(String encodedPassword) {
+        return User.builder()
+                .hubId(hubId)
+                .companyId(companyId)
+                .username(username)
+                .email(email)
+                .password(encodedPassword)
+                .role(role)
+                .build();
+    }
+
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserDto.java
@@ -1,0 +1,47 @@
+package com.sparta.ch4.delivery.user.application.dto;
+
+import com.sparta.ch4.delivery.user.domain.model.User;
+import com.sparta.ch4.delivery.user.domain.type.UserRole;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record UserDto(
+        Long id,
+        UUID hubId,
+        UUID companyId,
+        String username,
+        String email,
+        String password,
+        UserRole role,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy,
+        LocalDateTime deletedAt,
+        String deletedBy
+) {
+
+    public static UserDto from(User entity) {
+        return UserDto.builder()
+                .id(entity.getId())
+                .hubId(entity.getHubId())
+                .companyId(entity.getCompanyId())
+                .username(entity.getUsername())
+                .email(entity.getEmail())
+                .role(entity.getRole())
+                .password(entity.getPassword())
+                .isDeleted(entity.getIsDeleted())
+                .createdAt(entity.getCreatedAt())
+                .createdBy(entity.getCreatedBy())
+                .updatedAt(entity.getUpdatedAt())
+                .updatedBy(entity.getUpdatedBy())
+                .deletedAt(entity.getDeletedAt())
+                .deletedBy(entity.getDeletedBy())
+                .build();
+    }
+
+}
+

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserPageDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserPageDto.java
@@ -1,0 +1,17 @@
+package com.sparta.ch4.delivery.user.application.dto;
+
+import com.sparta.ch4.delivery.user.domain.type.UserRole;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserPageDto(
+        Long id,
+        UUID hubId,
+        UUID companyId,
+        String username,
+        String email,
+        UserRole role,
+        LocalDateTime createdAt
+) {
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserUpdateDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserUpdateDto.java
@@ -1,0 +1,18 @@
+package com.sparta.ch4.delivery.user.application.dto;
+
+import com.sparta.ch4.delivery.user.domain.type.UserRole;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record UserUpdateDto(
+        String username,
+        String email,
+        String password,
+        UserRole role,
+        UUID hubId,
+        UUID companyId,
+        String updatedBy
+) {
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/service/AuthService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/service/AuthService.java
@@ -1,0 +1,21 @@
+package com.sparta.ch4.delivery.user.application.service;
+
+import com.sparta.ch4.delivery.user.application.dto.RegisterDto;
+import com.sparta.ch4.delivery.user.domain.service.UserDomainService;
+import com.sparta.ch4.delivery.user.presentation.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserDomainService userDomainService;
+
+    @Transactional
+    public UserResponse register(RegisterDto dto) {
+        return UserResponse.fromUserDto(userDomainService.createUser(dto));
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/service/UserService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/service/UserService.java
@@ -1,0 +1,39 @@
+package com.sparta.ch4.delivery.user.application.service;
+
+import com.sparta.ch4.delivery.user.application.dto.UserUpdateDto;
+import com.sparta.ch4.delivery.user.domain.service.UserDomainService;
+import com.sparta.ch4.delivery.user.domain.type.UserSearchType;
+import com.sparta.ch4.delivery.user.presentation.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserDomainService userDomainService;
+
+    @Transactional(readOnly = true)
+    public UserResponse getUserById(Long userId) {
+        return UserResponse.fromUserDto(userDomainService.getUserById(userId));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserResponse> getUsers(UserSearchType searchType, String searchValue, Pageable pageable) {
+        return userDomainService.getUsers(searchType, searchValue, pageable).map(UserResponse::fromUserPageDto);
+    }
+
+    @Transactional
+    public UserResponse updateUser(Long userId, UserUpdateDto dto) {
+        return UserResponse.fromUserDto(userDomainService.updateUser(userId, dto));
+    }
+
+    @Transactional
+    public void deleteUser(Long userId, String deletedBy) {
+        userDomainService.deleteUserById(userId, deletedBy);
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/User.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/User.java
@@ -1,7 +1,9 @@
 package com.sparta.ch4.delivery.user.domain.model;
 
+import com.sparta.ch4.delivery.user.application.dto.UserUpdateDto;
 import com.sparta.ch4.delivery.user.domain.type.UserRole;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 
 import java.util.Objects;
@@ -50,6 +52,22 @@ public class User extends BaseEntity {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    public void update(UserUpdateDto dto, String password) {
+        this.username = dto.username();
+        this.email = dto.email();
+        this.role = dto.role();
+        this.password = password;
+        this.hubId = dto.hubId();
+        this.companyId = dto.companyId();
+        this.setUpdatedBy(dto.updatedBy());
+    }
+
+    public void delete(String deletedBy) {
+        this.setDeletedBy(deletedBy);
+        this.setDeletedAt(LocalDateTime.now());
+        this.setIsDeleted(true);
     }
 
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/repository/UserPageRepository.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/repository/UserPageRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.ch4.delivery.user.domain.repository;
+
+import com.sparta.ch4.delivery.user.application.dto.UserPageDto;
+import com.sparta.ch4.delivery.user.domain.type.UserSearchType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserPageRepository {
+    Page<UserPageDto> searchUser(UserSearchType searchType, String searchValue, Pageable pageable);
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/repository/UserRepository.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.ch4.delivery.user.domain.repository;
+
+import com.sparta.ch4.delivery.user.domain.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Boolean existsByUsername(String username);
+
+    Boolean existsByEmail(String email);
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/UserDomainService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/UserDomainService.java
@@ -1,0 +1,75 @@
+package com.sparta.ch4.delivery.user.domain.service;
+
+import com.sparta.ch4.delivery.user.application.dto.RegisterDto;
+import com.sparta.ch4.delivery.user.application.dto.UserDto;
+import com.sparta.ch4.delivery.user.application.dto.UserPageDto;
+import com.sparta.ch4.delivery.user.application.dto.UserUpdateDto;
+import com.sparta.ch4.delivery.user.domain.model.User;
+import com.sparta.ch4.delivery.user.domain.repository.UserPageRepository;
+import com.sparta.ch4.delivery.user.domain.repository.UserRepository;
+import com.sparta.ch4.delivery.user.domain.type.UserSearchType;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDomainService {
+
+    private final UserRepository userRepository;
+
+    private final UserPageRepository userPageRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    public UserDto createUser(RegisterDto dto) {
+        checkDuplicate(dto.username(), dto.email());
+
+        String encodedPassword = passwordEncoder.encode(dto.password());
+        User user = userRepository.save(dto.toEntity(encodedPassword));
+        user.setCreatedBy(String.valueOf(user.getId()));
+        return UserDto.from(userRepository.save(user));
+    }
+
+    public UserDto getUserById(Long userId) {
+       return userRepository.findById(userId).map(UserDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자가 존재하지 않습니다."));
+    }
+
+    public Page<UserPageDto> getUsers(UserSearchType searchType, String searchValue, Pageable pageable) {
+        return userPageRepository.searchUser(searchType, searchValue, pageable);
+    }
+
+    public UserDto updateUser(Long userId, UserUpdateDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자가 존재하지 않습니다."));
+        String password = passwordEncoder.encode(dto.password());
+        user.update(dto, password);
+        return UserDto.from(userRepository.save(user));
+    }
+
+    public void deleteUserById(Long userId, String deleteBy) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자가 존재하지 않습니다."));
+        user.delete(deleteBy);
+    }
+
+    private void checkDuplicate(String username, String email) {
+        if (userRepository.existsByUsername(username)) {
+            throw new IllegalArgumentException("이미 존재하는 사용자 이름입니다.");
+        }
+        if (userRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+    }
+
+    private void checkPassword(String currentPassword, String updatePassword) {
+        if (!passwordEncoder.matches(currentPassword, updatePassword)) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/UserDomainService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/UserDomainService.java
@@ -55,6 +55,7 @@ public class UserDomainService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자가 존재하지 않습니다."));
         user.delete(deleteBy);
+        userRepository.save(user);
     }
 
     private void checkDuplicate(String username, String email) {

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/type/UserRole.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/type/UserRole.java
@@ -1,8 +1,18 @@
 package com.sparta.ch4.delivery.user.domain.type;
 
+/**
+ * 시스템 내 사용자 역할을 나타내는 Enum입니다.
+ *
+ * <ul>
+ *   <li><b>MASTER</b>: 시스템 내 모든 권한을 가집니다.</li>
+ *   <li><b>HUB_MANAGER</b>: 자신이 소속된 허브에 속한 업체들만 관리할 수 있습니다.</li>
+ *   <li><b>HUB_DELIVERY</b>: 허브 간 배송을 담당하는 역할입니다.</li>
+ *   <li><b>HUB_COMPANY</b>: 자신의 업체 정보만 수정 가능하며, 다른 업체에 대해서는 조회 및 검색만 가능합니다.</li>
+ * </ul>
+ */
 public enum UserRole {
     MASTER,       // 마스터 관리자
     HUB_MANAGER,  // 허브 관리자
     HUB_DELIVERY, // 허브 배송담당자
-    HUB_COMPANY  // 허브 업체 관리자
+    HUB_COMPANY   // 허브 업체 관리자
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/type/UserSearchType.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/type/UserSearchType.java
@@ -1,0 +1,8 @@
+package com.sparta.ch4.delivery.user.domain.type;
+
+public enum UserSearchType {
+    USERNAME,
+    EMAIL,
+    HUB_ID,
+    COMPANY_ID
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/config/JpaConfig.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/config/JpaConfig.java
@@ -1,0 +1,17 @@
+package com.sparta.ch4.delivery.user.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManagerFactory entityManagerFactory) {
+        return new JPAQueryFactory(entityManagerFactory.createEntityManager());
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/config/SecurityConfig.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.sparta.ch4.delivery.user.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/UserPageRepositoryImpl.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/UserPageRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.sparta.ch4.delivery.user.infrastructure.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.ch4.delivery.user.application.dto.UserPageDto;
+import com.sparta.ch4.delivery.user.domain.model.QUser;
+import com.sparta.ch4.delivery.user.domain.repository.UserPageRepository;
+import com.sparta.ch4.delivery.user.domain.type.UserSearchType;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class UserPageRepositoryImpl implements UserPageRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    QUser user = QUser.user;
+
+    // TODO: 삭제된 레코드 조회 제외?
+    @Override
+    public Page<UserPageDto> searchUser(UserSearchType searchType, String searchValue, Pageable pageable) {
+
+        List<UserPageDto> results = queryFactory
+                .select(Projections.constructor(
+                        UserPageDto.class,
+                        user.id.as("id"),
+                        user.hubId.as("hubId"),
+                        user.companyId.as("companyId"),
+                        user.username,
+                        user.email,
+                        user.role,
+                        user.createdAt
+                ))
+                .from(user)
+                .where(getSearchPredicate(searchType, searchValue))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(user.count())
+                .from(user)
+                .where(getSearchPredicate(searchType, searchValue))
+                .fetchOne();
+
+        assert total != null;
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private BooleanExpression getSearchPredicate(UserSearchType searchType, String searchValue) {
+        if (searchType == null || searchValue == null) {
+            return null;
+        }
+        return switch (searchType) {
+            case USERNAME -> user.username.containsIgnoreCase(searchValue);
+            case EMAIL -> user.email.eq(searchValue);
+            case HUB_ID -> user.hubId.eq(UUID.fromString(searchValue));
+            case COMPANY_ID ->
+                    user.companyId.eq(UUID.fromString(searchValue));
+        };
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/AuthController.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.sparta.ch4.delivery.user.presentation.controller;
+
+import com.sparta.ch4.delivery.user.application.service.AuthService;
+import com.sparta.ch4.delivery.user.presentation.request.RegisterRequest;
+import com.sparta.ch4.delivery.user.presentation.response.CommonResponse;
+import com.sparta.ch4.delivery.user.presentation.response.UserResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    public CommonResponse<UserResponse> register(
+            @Valid @RequestBody RegisterRequest request) {
+        return CommonResponse.success(authService.register(request.toDto()));
+    }
+
+    // TODO: 로그인 시 토큰 발급
+//    @PostMapping("/login")
+//    public ResponseEntity<TokenDto> login(@RequestBody LoginRequest request) {
+//
+//    }
+
+    // TODO 도전 기능: 비밀번호 초기화
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/UserController.java
@@ -1,0 +1,64 @@
+package com.sparta.ch4.delivery.user.presentation.controller;
+
+import com.sparta.ch4.delivery.user.application.service.UserService;
+import com.sparta.ch4.delivery.user.domain.type.UserSearchType;
+import com.sparta.ch4.delivery.user.presentation.request.UserUpdateRequest;
+import com.sparta.ch4.delivery.user.presentation.response.CommonResponse;
+import com.sparta.ch4.delivery.user.presentation.response.UserResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/{userId}")
+    public CommonResponse<UserResponse> getUser(@PathVariable Long userId) {
+        return CommonResponse.success(userService.getUserById(userId));
+    }
+
+    @GetMapping
+    public CommonResponse<Page<UserResponse>> getUsers(
+            @RequestParam(required = false, name = "searchType") UserSearchType searchType,
+            @RequestParam(required = false, name = "searchValue") String searchValue,
+            @PageableDefault(
+                    size = 10, sort = {"createdAt", "updatedAt"}, direction = Sort.Direction.DESC
+            ) Pageable pageable) {
+        return CommonResponse.success(userService.getUsers(searchType, searchValue, pageable));
+    }
+
+    @PutMapping("/{userId}")
+    public CommonResponse<UserResponse> updateUser(
+            @RequestHeader("X-UserId") String updatedBy,
+            @PathVariable Long userId,
+            @Valid @RequestBody UserUpdateRequest updateUserRequest) {
+        return CommonResponse.success(userService.updateUser(userId, updateUserRequest.toDto(updatedBy)));
+    }
+
+    @DeleteMapping("/{userId}")
+    @ResponseStatus(code = HttpStatus.NO_CONTENT)
+    public void deleteUser(
+            @RequestHeader("X-UserId") String deleteBy,
+            @PathVariable Long userId) {
+        userService.deleteUser(userId, deleteBy);
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/LoginRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.sparta.ch4.delivery.user.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest(
+        @NotBlank(message = "사용자 이름은 필수입니다.")
+        @Size(min = 4, max = 10, message = "사용자 이름은 4자에서 10자 사이여야 합니다.")
+        @Pattern(regexp = "^[a-z0-9]+$", message = "사용자 이름은 소문자 알파벳과 숫자만 포함해야 합니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자 사이여야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).+$",
+                message = "비밀번호는 최소 한 개의 알파벳, 숫자, 특수 문자를 포함해야 합니다.")
+        String password
+) {
+}
+

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/RegisterRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/RegisterRequest.java
@@ -1,0 +1,47 @@
+package com.sparta.ch4.delivery.user.presentation.request;
+
+import com.sparta.ch4.delivery.user.application.dto.RegisterDto;
+import com.sparta.ch4.delivery.user.domain.type.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record RegisterRequest(
+        @NotBlank(message = "사용자 이름은 필수입니다.")
+        @Size(min = 4, max = 10, message = "사용자 이름은 4자에서 10자 사이여야 합니다.")
+        @Pattern(regexp = "^[a-z0-9]+$", message = "사용자 이름은 소문자 알파벳과 숫자만 포함해야 합니다.")
+        String username,
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이어야 합니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자 사이여야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).+$",
+                message = "비밀번호는 최소 한 개의 알파벳, 숫자, 특수 문자를 포함해야 합니다.")
+        String password,
+
+        @NotNull(message = "역할은 필수입니다.")
+        UserRole role,
+
+        UUID hubId,
+
+        UUID companyId
+) {
+        public RegisterDto toDto() {
+                return RegisterDto.builder()
+                        .hubId(hubId)
+                        .companyId(companyId)
+                        .username(username)
+                        .password(password)
+                        .email(email)
+                        .role(role)
+                        .build();
+        }
+}
+
+

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/UserUpdateRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/UserUpdateRequest.java
@@ -1,0 +1,46 @@
+package com.sparta.ch4.delivery.user.presentation.request;
+
+import com.sparta.ch4.delivery.user.application.dto.UserUpdateDto;
+import com.sparta.ch4.delivery.user.domain.type.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record UserUpdateRequest(
+        @NotBlank(message = "사용자 이름은 필수입니다.")
+        @Size(min = 4, max = 10, message = "사용자 이름은 4자에서 10자 사이여야 합니다.")
+        @Pattern(regexp = "^[a-z0-9]+$", message = "사용자 이름은 소문자 알파벳과 숫자만 포함해야 합니다.")
+        String username,
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이어야 합니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자 사이여야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).+$",
+                message = "비밀번호는 최소 한 개의 알파벳, 숫자, 특수 문자를 포함해야 합니다.")
+        String password,
+
+        @NotNull(message = "역할은 필수입니다.")
+        UserRole role,
+
+        UUID hubId,
+
+        UUID companyId
+) {
+    public UserUpdateDto toDto(String updatedBy) {
+        return UserUpdateDto.builder()
+                .username(username)
+                .email(email)
+                .password(password)
+                .role(role)
+                .hubId(hubId)
+                .companyId(companyId)
+                .updatedBy(updatedBy)
+                .build();
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/CommonResponse.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/CommonResponse.java
@@ -1,0 +1,21 @@
+package com.sparta.ch4.delivery.user.presentation.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CommonResponse<T> {
+
+    private int status;
+    private String message;
+    private T data;
+
+    // 엔티티 생성 / 조회 / 수정 성공 반환
+    public static <T> CommonResponse<T> success(T data) {
+        return new CommonResponse<>(200, "success", data);
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/UserResponse.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/UserResponse.java
@@ -1,0 +1,44 @@
+package com.sparta.ch4.delivery.user.presentation.response;
+
+import com.sparta.ch4.delivery.user.application.dto.UserDto;
+import com.sparta.ch4.delivery.user.application.dto.UserPageDto;
+import com.sparta.ch4.delivery.user.domain.type.UserRole;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record UserResponse(
+        Long id,
+        UUID hubId,
+        UUID companyId,
+        String username,
+        String email,
+        UserRole role,
+        LocalDateTime createdAt
+) {
+    public static UserResponse fromUserDto(UserDto dto) {
+        return UserResponse.builder()
+                .id(dto.id())
+                .hubId(dto.hubId())
+                .companyId(dto.companyId())
+                .username(dto.username())
+                .email(dto.email())
+                .role(dto.role())
+                .createdAt(dto.createdAt())
+                .build();
+    }
+
+    public static UserResponse fromUserPageDto(UserPageDto dto) {
+        return UserResponse.builder()
+                .id(dto.id())
+                .hubId(dto.hubId())
+                .companyId(dto.companyId())
+                .username(dto.username())
+                .email(dto.email())
+                .role(dto.role())
+                .createdAt(dto.createdAt())
+                .build();
+    }
+}
+


### PR DESCRIPTION
close #11

## 구현 내용
- 회원가입
- 사용자 조회
- 사용자 페이지 조회
- 사용자 삭제 (deletedBy에 표시할 `X-UserId` 헤더 필요)
- 사용자 수정 (updatedBy에 표시할 `X-UserId` 헤더 필요)

## TODO
- 로그인 및 JWT 발급
- 테스트 코드 작성
- Swagger 통합 
- `isDeleted`에 따른 조회 조건 