### PR TITLE
feat: User 엔티티에 slackId 추가

### DIFF
--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/RegisterDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/RegisterDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 public record RegisterDto(
         UUID hubId,
         UUID companyId,
+        String slackId,
         String username,
         String email,
         String password,
@@ -20,6 +21,7 @@ public record RegisterDto(
         return User.builder()
                 .hubId(hubId)
                 .companyId(companyId)
+                .slackId(slackId)
                 .username(username)
                 .email(email)
                 .password(encodedPassword)

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserDto.java
@@ -11,6 +11,7 @@ public record UserDto(
         Long id,
         UUID hubId,
         UUID companyId,
+        String slackId,
         String username,
         String email,
         String password,
@@ -29,6 +30,7 @@ public record UserDto(
                 .id(entity.getId())
                 .hubId(entity.getHubId())
                 .companyId(entity.getCompanyId())
+                .slackId(entity.getSlackId())
                 .username(entity.getUsername())
                 .email(entity.getEmail())
                 .role(entity.getRole())

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserPageDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserPageDto.java
@@ -10,6 +10,7 @@ public record UserPageDto(
         UUID companyId,
         String username,
         String email,
+        String slackId,
         UserRole role,
         LocalDateTime createdAt
 ) {

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserUpdateDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserUpdateDto.java
@@ -9,6 +9,7 @@ public record UserUpdateDto(
         String username,
         String email,
         String password,
+        String slackId,
         UserRole role,
         UUID hubId,
         UUID companyId,

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/User.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/User.java
@@ -37,6 +37,9 @@ public class User extends BaseEntity {
     @Column(name = "password", nullable = false)
     private String password;
 
+    @Column(name = "slack_id", nullable = false)
+    private String slackId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private UserRole role;
@@ -61,6 +64,7 @@ public class User extends BaseEntity {
         this.password = password;
         this.hubId = dto.hubId();
         this.companyId = dto.companyId();
+        this.slackId = dto.slackId();
         this.setUpdatedBy(dto.updatedBy());
     }
 

--- a/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/UserPageRepositoryImpl.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/UserPageRepositoryImpl.java
@@ -30,9 +30,10 @@ public class UserPageRepositoryImpl implements UserPageRepository {
         List<UserPageDto> results = queryFactory
                 .select(Projections.constructor(
                         UserPageDto.class,
-                        user.id.as("id"),
-                        user.hubId.as("hubId"),
-                        user.companyId.as("companyId"),
+                        user.id,
+                        user.hubId,
+                        user.companyId,
+                        user.slackId,
                         user.username,
                         user.email,
                         user.role,

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/RegisterRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/RegisterRequest.java
@@ -28,6 +28,9 @@ public record RegisterRequest(
         @NotNull(message = "역할은 필수입니다.")
         UserRole role,
 
+        @NotBlank(message = "Slack 아이디는 필수입니다.")
+        String slackId,
+
         UUID hubId,
 
         UUID companyId
@@ -36,6 +39,7 @@ public record RegisterRequest(
                 return RegisterDto.builder()
                         .hubId(hubId)
                         .companyId(companyId)
+                        .slackId(slackId)
                         .username(username)
                         .password(password)
                         .email(email)

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/UserUpdateRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/UserUpdateRequest.java
@@ -28,6 +28,9 @@ public record UserUpdateRequest(
         @NotNull(message = "역할은 필수입니다.")
         UserRole role,
 
+        @NotBlank(message = "Slack 아이디는 필수입니다.")
+        String slackId,
+
         UUID hubId,
 
         UUID companyId
@@ -40,6 +43,7 @@ public record UserUpdateRequest(
                 .role(role)
                 .hubId(hubId)
                 .companyId(companyId)
+                .slackId(slackId)
                 .updatedBy(updatedBy)
                 .build();
     }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/UserResponse.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/UserResponse.java
@@ -13,6 +13,7 @@ public record UserResponse(
         Long id,
         UUID hubId,
         UUID companyId,
+        String slackId,
         String username,
         String email,
         UserRole role,
@@ -23,6 +24,7 @@ public record UserResponse(
                 .id(entity.getId())
                 .hubId(entity.getHubId())
                 .companyId(entity.getCompanyId())
+                .slackId(entity.getSlackId())
                 .username(entity.getUsername())
                 .email(entity.getEmail())
                 .role(entity.getRole())
@@ -35,6 +37,7 @@ public record UserResponse(
                 .id(dto.id())
                 .hubId(dto.hubId())
                 .companyId(dto.companyId())
+                .slackId(dto.slackId())
                 .username(dto.username())
                 .email(dto.email())
                 .role(dto.role())
@@ -47,6 +50,7 @@ public record UserResponse(
                 .id(dto.id())
                 .hubId(dto.hubId())
                 .companyId(dto.companyId())
+                .slackId(dto.slackId())
                 .username(dto.username())
                 .email(dto.email())
                 .role(dto.role())


### PR DESCRIPTION
Order 에서 slack ID를 추가해야 하기 때문에, 사용자 테이블에 `slackId`(슬랙 로그인할 때 쓰는 아이디)를 추가합니다.
수정 사항은 ERD 및 테이블 명세서에 반영해두겠습니다.

close #27 