### PR TITLE
feat: User 서버에 Slack 엔티티 구현

### DIFF
--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackMessageDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackMessageDto.java
@@ -12,7 +12,7 @@ public record SlackMessageDto (
         String userSlackId,      // 사용자가 사용하는 슬랙 ID
         UUID slackMessageId, // 슬랙 고유 ID
         String message,    // 수신한 메시지 내용
-        LocalDateTime sentAt // 수신한 시간
+        LocalDateTime receivedAt // 수신한 시간
 )
 {
     public Slack toEntity(User user) {
@@ -31,7 +31,7 @@ public record SlackMessageDto (
                 .userId(entity.getUser().getId())
                 .message(entity.getMessage())
                 .userSlackId(entity.getSlackId())
-                .sentAt(entity.getCreatedAt())
+                .receivedAt(entity.getCreatedAt())
                 .build();
     }
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackMessageDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackMessageDto.java
@@ -1,0 +1,37 @@
+package com.sparta.ch4.delivery.user.application.dto;
+
+import com.sparta.ch4.delivery.user.domain.model.Slack;
+import com.sparta.ch4.delivery.user.domain.model.User;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record SlackMessageDto (
+        Long userId, // 사용자 DB ID
+        String userSlackId,      // 사용자가 사용하는 슬랙 ID
+        UUID slackMessageId, // 슬랙 고유 ID
+        String message,    // 수신한 메시지 내용
+        LocalDateTime sentAt // 수신한 시간
+)
+{
+    public Slack toEntity(User user) {
+        Slack slack = Slack.builder()
+                .slackId(userSlackId)
+                .user(user)
+                .message(message)
+                .build();
+        slack.setCreatedBy(userSlackId);
+        return slack;
+    }
+
+    public static SlackMessageDto fromEntity(Slack entity) {
+        return SlackMessageDto.builder()
+                .slackMessageId(entity.getId())
+                .userId(entity.getUser().getId())
+                .message(entity.getMessage())
+                .userSlackId(entity.getSlackId())
+                .sentAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackMessageDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackMessageDto.java
@@ -21,7 +21,7 @@ public record SlackMessageDto (
                 .user(user)
                 .message(message)
                 .build();
-        slack.setCreatedBy(userSlackId);
+        slack.setCreatedBy(String.valueOf(userId));
         return slack;
     }
 

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserUpdateDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/UserUpdateDto.java
@@ -9,7 +9,6 @@ public record UserUpdateDto(
         String username,
         String email,
         String password,
-        String slackId,
         UserRole role,
         UUID hubId,
         UUID companyId,

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/service/SlackService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/service/SlackService.java
@@ -1,0 +1,30 @@
+package com.sparta.ch4.delivery.user.application.service;
+
+import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import com.sparta.ch4.delivery.user.domain.service.SlackDomainService;
+import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
+import com.sparta.ch4.delivery.user.presentation.response.SlackResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SlackService {
+
+    private final SlackDomainService slackDomainService;
+
+    @Transactional
+    public SlackResponse saveSlackMessage(SlackMessageDto dto) {
+        return SlackResponse.fromSlackMessageDto(slackDomainService.saveSlackMessage(dto));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SlackResponse> getSlackMessages(
+            SlackSearchType searchType, String searchValue, Pageable pageable) {
+        return slackDomainService.getSlackMessages(searchType, searchValue, pageable).map(SlackResponse::fromSlackMessageDto);
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/Slack.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/Slack.java
@@ -1,0 +1,56 @@
+package com.sparta.ch4.delivery.user.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_slack")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class Slack extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, unique = true)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "slack_id", nullable = false)
+    private String slackId;
+
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Slack slack = (Slack) o;
+        return Objects.equals(id, slack.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/User.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/User.java
@@ -37,7 +37,7 @@ public class User extends BaseEntity {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "slack_id", nullable = false)
+    @Column(name = "slack_id", nullable = false, unique = true)
     private String slackId;
 
     @Enumerated(EnumType.STRING)
@@ -64,7 +64,6 @@ public class User extends BaseEntity {
         this.password = password;
         this.hubId = dto.hubId();
         this.companyId = dto.companyId();
-        this.slackId = dto.slackId();
         this.setUpdatedBy(dto.updatedBy());
     }
 

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/repository/SlackPageRepository.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/repository/SlackPageRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.ch4.delivery.user.domain.repository;
+
+import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SlackPageRepository {
+    Page<SlackMessageDto> searchMessages(SlackSearchType searchType, String searchValue, Pageable pageable);
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/repository/SlackRepository.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/repository/SlackRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.ch4.delivery.user.domain.repository;
+
+import com.sparta.ch4.delivery.user.domain.model.Slack;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SlackRepository extends JpaRepository<Slack, UUID> {
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/SlackDomainService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/SlackDomainService.java
@@ -1,0 +1,39 @@
+package com.sparta.ch4.delivery.user.domain.service;
+
+import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import com.sparta.ch4.delivery.user.domain.model.Slack;
+import com.sparta.ch4.delivery.user.domain.model.User;
+import com.sparta.ch4.delivery.user.domain.repository.SlackPageRepository;
+import com.sparta.ch4.delivery.user.domain.repository.SlackRepository;
+import com.sparta.ch4.delivery.user.domain.repository.UserRepository;
+import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SlackDomainService {
+
+    private final UserRepository userRepository;
+
+    private final SlackRepository slackRepository;
+
+    private final SlackPageRepository slackPageRepository;
+
+    public SlackMessageDto saveSlackMessage(SlackMessageDto dto) {
+        User user = userRepository.findById(dto.userId())
+                .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자를 찾을 수 없습니다."));
+        Slack slack = slackRepository.save(dto.toEntity(user));
+        return SlackMessageDto.fromEntity(slack);
+    }
+
+    public Page<SlackMessageDto> getSlackMessages(SlackSearchType searchType, String searchValue,
+            Pageable pageable) {
+        return slackPageRepository.searchMessages(searchType, searchValue, pageable);
+    }
+
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/type/SlackSearchType.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/type/SlackSearchType.java
@@ -1,0 +1,8 @@
+package com.sparta.ch4.delivery.user.domain.type;
+
+public enum SlackSearchType {
+    SLACK_ID,         // Slack ID로 검색 (특정 사용자 또는 수신자의 메시지)
+    MESSAGE_CONTENT,  // 메시지 내용으로 검색 (특정 키워드를 포함한 메시지)
+    // TODO: 특정 날짜에 메세지 검색?
+}
+

--- a/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/SlackPageRepositoryImpl.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/SlackPageRepositoryImpl.java
@@ -31,7 +31,7 @@ public class SlackPageRepositoryImpl implements SlackPageRepository {
                         slack.slackId,
                         slack.id.as("slackMessageId"),
                         slack.message,
-                        slack.createdAt.as("sentAt")
+                        slack.createdAt.as("receivedAt")
                 ))
                 .from(slack)
                 .where(getSearchPredicate(searchType, searchValue))

--- a/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/SlackPageRepositoryImpl.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/SlackPageRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.sparta.ch4.delivery.user.infrastructure.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import com.sparta.ch4.delivery.user.domain.model.QSlack;
+import com.sparta.ch4.delivery.user.domain.repository.SlackPageRepository;
+import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SlackPageRepositoryImpl implements SlackPageRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    QSlack slack = QSlack.slack;
+
+    public Page<SlackMessageDto> searchMessages(SlackSearchType searchType, String searchValue, Pageable pageable) {
+
+        List<SlackMessageDto> results = queryFactory
+                .select(Projections.constructor(
+                        SlackMessageDto.class,
+                        slack.user.id.as("userId"),
+                        slack.slackId,
+                        slack.id.as("slackMessageId"),
+                        slack.message,
+                        slack.createdAt.as("sentAt")
+                ))
+                .from(slack)
+                .where(getSearchPredicate(searchType, searchValue))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(slack.count())
+                .from(slack)
+                .where(getSearchPredicate(searchType, searchValue))
+                .fetchOne();
+
+        assert total != null;
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    // 검색 조건 생성
+    private BooleanExpression getSearchPredicate(SlackSearchType searchType, String searchValue) {
+
+        if (searchType == null || searchValue == null) {
+            return null;
+        }
+
+        return switch (searchType) {
+            case SLACK_ID -> slack.slackId.containsIgnoreCase(searchValue);
+            case MESSAGE_CONTENT -> slack.message.containsIgnoreCase(searchValue);
+        };
+    }
+}
+

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/SlackController.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/SlackController.java
@@ -1,0 +1,53 @@
+package com.sparta.ch4.delivery.user.presentation.controller;
+
+import com.sparta.ch4.delivery.user.application.service.SlackService;
+import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
+import com.sparta.ch4.delivery.user.presentation.request.SlackSendMessageRequest;
+import com.sparta.ch4.delivery.user.presentation.response.CommonResponse;
+import com.sparta.ch4.delivery.user.presentation.response.SlackResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/slack")
+@RequiredArgsConstructor
+public class SlackController {
+
+    private final SlackService slackService;
+
+    // TODO: Slack WebHook 연동
+//    @PostMapping
+//    public CommonResponse<SlackResponse> sendSlackMessage(
+//    }
+
+
+    // FIXME: Slack App에서 보내는 메시지를 받아야 합니다. 현재는 임시로 구현되어 있습니다.
+    @PostMapping("/events")
+    public CommonResponse<SlackResponse> receiveSlackMessage(
+            @Valid @RequestBody SlackSendMessageRequest request,
+            @RequestHeader("X-UserId") String userId) {
+        return CommonResponse.success(slackService.saveSlackMessage(request.toDto(userId)));
+    }
+
+    @GetMapping
+    public CommonResponse<Page<SlackResponse>> getAllSlackMessages(
+            @RequestParam(required = false, name = "searchType") SlackSearchType searchType,
+            @RequestParam(required = false, name = "searchValue") String searchValue,
+            @PageableDefault(
+                    size = 10, sort = {"createdAt", "updatedAt"}, direction = Sort.Direction.DESC
+            ) Pageable pageable) {
+        return CommonResponse.success(slackService.getSlackMessages(searchType, searchValue, pageable));
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/SlackSendMessageRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/SlackSendMessageRequest.java
@@ -1,0 +1,21 @@
+package com.sparta.ch4.delivery.user.presentation.request;
+
+import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import jakarta.validation.constraints.NotBlank;
+
+public record SlackSendMessageRequest (
+        @NotBlank(message = "사용자 Slack 아이디는 필수입니다.")
+        String userSlackId,
+
+        @NotBlank(message = "메시지는 내용은 필수입니다.")
+        String message
+) {
+    public SlackMessageDto toDto(String userId) {
+        return SlackMessageDto.builder()
+                .userSlackId(userSlackId)
+                .userId(Long.valueOf(userId))
+                .message(message)
+                .build();
+    }
+}
+

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/UserUpdateRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/UserUpdateRequest.java
@@ -28,9 +28,6 @@ public record UserUpdateRequest(
         @NotNull(message = "역할은 필수입니다.")
         UserRole role,
 
-        @NotBlank(message = "Slack 아이디는 필수입니다.")
-        String slackId,
-
         UUID hubId,
 
         UUID companyId
@@ -43,7 +40,6 @@ public record UserUpdateRequest(
                 .role(role)
                 .hubId(hubId)
                 .companyId(companyId)
-                .slackId(slackId)
                 .updatedBy(updatedBy)
                 .build();
     }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/SlackResponse.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/SlackResponse.java
@@ -11,7 +11,7 @@ public record SlackResponse(
         String userSlackId,
         UUID slackMessageId,
         String message,
-        LocalDateTime sentAt
+        LocalDateTime receivedAt
 ) {
     public static SlackResponse fromSlackMessageDto(SlackMessageDto dto) {
         return SlackResponse.builder()
@@ -19,7 +19,7 @@ public record SlackResponse(
                 .userSlackId(dto.userSlackId())
                 .slackMessageId(dto.slackMessageId())
                 .message(dto.message())
-                .sentAt(dto.sentAt())
+                .receivedAt(dto.receivedAt())
                 .build();
     }
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/SlackResponse.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/SlackResponse.java
@@ -1,0 +1,25 @@
+package com.sparta.ch4.delivery.user.presentation.response;
+
+import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record SlackResponse(
+        Long userId,
+        String userSlackId,
+        UUID slackMessageId,
+        String message,
+        LocalDateTime sentAt
+) {
+    public static SlackResponse fromSlackMessageDto(SlackMessageDto dto) {
+        return SlackResponse.builder()
+                .userId(dto.userId())
+                .userSlackId(dto.userSlackId())
+                .slackMessageId(dto.slackMessageId())
+                .message(dto.message())
+                .sentAt(dto.sentAt())
+                .build();
+    }
+}


### PR DESCRIPTION
close #31 

### 구현 내용
- Slack 엔티티 구현, `User`와 **다대일** 단방향 매핑이 되어있습니다.
- Slack 엔티티는 **사용자가 받은 메시지 내역을 저장합니다.**
- Slack 엔티티 조회 방식에는 **사용자의 Slack Id 기준**, **특정 키워드가 메시지 포함되어 있는지**로 검색할 수 있습니다.

### 주요 사항
- 원래 메시지 단건 조회가 API 명세서에 있었는데, 메시지를 단 건으로 조회할 일은 없을 것 같아서 검색만 구현했습니다.
- 추후 **Slack App과 연동하여** 메시지 수신/발신을 구현해야 합니다. 아마 Slack App에서 우리 서버 엔드포인트로 요청을 보내고, 서버에서 받는 방식으로 진행되어야 할거라 `receiveSlackMessage`는 바꿔야할 것 같습니다.
- 사용자가 `slackId` 를 일단 바꿀 수 없게 하였습니다. 만약 바꿀 수 있다면 그 user와 연결되어 있는 slack 메시지를 모두 update 해주어야 하는데, 이 정책은 추후 정해봐야 할 것 같습니다.

### 예시 요청 및 응답
`POST http://localhost:19091/api/slack`
Header: `X-UserId: 1`
request
```json
{
  "userSlackId": "john_doe_slack",
  "message": "Hello, this is a test message!"
}
```
response
```json
{
    "status": 200,
    "message": "success",
    "data": {
        "userId": 1,
        "userSlackId": "john_doe_slack",
        "slackMessageId": "3b8b7f0e-43f3-4375-8446-00125237d8ec",
        "message": "Hello, this is a test message!",
        "receivedAt": "2024-09-11T17:28:54.5833884"
    }
}
```

`GET http://localhost:19091/api/slack/events?searchType=MESSAGE_CONTENT&searchValue=this&page=0&size=10` 
```json
{
    "status": 200,
    "message": "success",
    "data": {
        "content": [
            {
                "userId": 1,
                "userSlackId": "john_doe_slack",
                "slackMessageId": "3b8b7f0e-43f3-4375-8446-00125237d8ec",
                "message": "Hello, this is a test message!",
                "receivedAt": "2024-09-11T17:28:54.583388"
            }
        ],
        "page": {
            "size": 10,
            "number": 0,
            "totalElements": 1,
            "totalPages": 1
        }
    }
}

```