### PR TITLE
feat: Slack과 User 서버 연동

### DIFF
--- a/user/docker-compose.yml
+++ b/user/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       JWT_EXPIRATION_TIME: ${JWT_EXPIRATION_TIME}
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
 
 networks:
   delivery-msa-net:

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackMessageDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackMessageDto.java
@@ -1,36 +1,23 @@
 package com.sparta.ch4.delivery.user.application.dto;
 
 import com.sparta.ch4.delivery.user.domain.model.Slack;
-import com.sparta.ch4.delivery.user.domain.model.User;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record SlackMessageDto (
-        Long userId, // 사용자 DB ID
-        String userSlackId,      // 사용자가 사용하는 슬랙 ID
-        UUID slackMessageId, // 슬랙 고유 ID
+        String receiverSlackId,      // 수신자의 슬랙 아이디
+        UUID slackMessageId, // 슬랙 레코드 ID
         String message,    // 수신한 메시지 내용
         LocalDateTime receivedAt // 수신한 시간
 )
 {
-    public Slack toEntity(User user) {
-        Slack slack = Slack.builder()
-                .slackId(userSlackId)
-                .user(user)
-                .message(message)
-                .build();
-        slack.setCreatedBy(String.valueOf(userId));
-        return slack;
-    }
-
     public static SlackMessageDto fromEntity(Slack entity) {
         return SlackMessageDto.builder()
+                .receiverSlackId(entity.getReceiverSlackId())
                 .slackMessageId(entity.getId())
-                .userId(entity.getUser().getId())
                 .message(entity.getMessage())
-                .userSlackId(entity.getSlackId())
                 .receivedAt(entity.getCreatedAt())
                 .build();
     }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackSendMessageDto.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/dto/SlackSendMessageDto.java
@@ -1,0 +1,18 @@
+package com.sparta.ch4.delivery.user.application.dto;
+
+import com.sparta.ch4.delivery.user.domain.model.Slack;
+import lombok.Builder;
+
+@Builder
+public record SlackSendMessageDto(
+        String receiverSlackId,
+        String message
+)
+{
+    public Slack toEntity() {
+        return Slack.builder()
+                .receiverSlackId(receiverSlackId)
+                .message(message)
+                .build();
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/service/SlackService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/service/SlackService.java
@@ -1,14 +1,20 @@
 package com.sparta.ch4.delivery.user.application.service;
 
-import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import com.sparta.ch4.delivery.user.application.dto.SlackSendMessageDto;
 import com.sparta.ch4.delivery.user.domain.service.SlackDomainService;
 import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
 import com.sparta.ch4.delivery.user.presentation.response.SlackResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -16,8 +22,26 @@ public class SlackService {
 
     private final SlackDomainService slackDomainService;
 
+    @Value("${slack.webhook-url}")
+    private String webhookUrl;
+
     @Transactional
-    public SlackResponse saveSlackMessage(SlackMessageDto dto) {
+    public SlackResponse sendSlackMessage(SlackSendMessageDto dto) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        String payload = getPayload(dto.receiverSlackId(), dto.message());
+        HttpEntity<String> request = new HttpEntity<>(payload, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            restTemplate.exchange(webhookUrl, HttpMethod.POST, request, String.class);
+        } catch (RestClientException e) {
+            throw new RestClientException("Slack 메시지 전송 중 에러가 발생했습니다.");
+        }
+        return saveSlackMessage(dto);
+    }
+
+    public SlackResponse saveSlackMessage(SlackSendMessageDto dto) {
         return SlackResponse.fromSlackMessageDto(slackDomainService.saveSlackMessage(dto));
     }
 
@@ -25,6 +49,16 @@ public class SlackService {
     public Page<SlackResponse> getSlackMessages(
             SlackSearchType searchType, String searchValue, Pageable pageable) {
         return slackDomainService.getSlackMessages(searchType, searchValue, pageable).map(SlackResponse::fromSlackMessageDto);
+    }
+
+    private String getPayload(String recipientSlackId, String message) {
+        return String.format("""
+                {
+                    "channel": "@%s",
+                    "username": "IS20bot",
+                    "text": "%s"
+                }
+                """, recipientSlackId, message);
     }
 
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/Slack.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/model/Slack.java
@@ -2,20 +2,21 @@ package com.sparta.ch4.delivery.user.domain.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.util.Objects;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "p_slack")
@@ -23,34 +24,23 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @Builder
-public class Slack extends BaseEntity {
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode
+public class Slack {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id", nullable = false, unique = true)
     private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
-
-    @Column(name = "slack_id", nullable = false)
-    private String slackId;
+    @Column(name = "receiver_slack_id", nullable = false)
+    private String receiverSlackId;
 
     @Column(name = "message", nullable = false)
     private String message;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Slack slack = (Slack) o;
-        return Objects.equals(id, slack.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
 
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/SlackDomainService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/SlackDomainService.java
@@ -1,13 +1,11 @@
 package com.sparta.ch4.delivery.user.domain.service;
 
 import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import com.sparta.ch4.delivery.user.application.dto.SlackSendMessageDto;
 import com.sparta.ch4.delivery.user.domain.model.Slack;
-import com.sparta.ch4.delivery.user.domain.model.User;
 import com.sparta.ch4.delivery.user.domain.repository.SlackPageRepository;
 import com.sparta.ch4.delivery.user.domain.repository.SlackRepository;
-import com.sparta.ch4.delivery.user.domain.repository.UserRepository;
 import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,17 +15,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SlackDomainService {
 
-    private final UserRepository userRepository;
-
     private final SlackRepository slackRepository;
 
     private final SlackPageRepository slackPageRepository;
 
-    public SlackMessageDto saveSlackMessage(SlackMessageDto dto) {
-        User user = userRepository.findById(dto.userId())
-                .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자를 찾을 수 없습니다."));
-        Slack slack = slackRepository.save(dto.toEntity(user));
-        return SlackMessageDto.fromEntity(slack);
+    public SlackMessageDto saveSlackMessage(SlackSendMessageDto dto) {
+        return SlackMessageDto.fromEntity(slackRepository.save(dto.toEntity()));
     }
 
     public Page<SlackMessageDto> getSlackMessages(SlackSearchType searchType, String searchValue,

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/SlackDomainService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/SlackDomainService.java
@@ -2,7 +2,6 @@ package com.sparta.ch4.delivery.user.domain.service;
 
 import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
 import com.sparta.ch4.delivery.user.application.dto.SlackSendMessageDto;
-import com.sparta.ch4.delivery.user.domain.model.Slack;
 import com.sparta.ch4.delivery.user.domain.repository.SlackPageRepository;
 import com.sparta.ch4.delivery.user.domain.repository.SlackRepository;
 import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;

--- a/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/SlackPageRepositoryImpl.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/repository/SlackPageRepositoryImpl.java
@@ -27,8 +27,7 @@ public class SlackPageRepositoryImpl implements SlackPageRepository {
         List<SlackMessageDto> results = queryFactory
                 .select(Projections.constructor(
                         SlackMessageDto.class,
-                        slack.user.id.as("userId"),
-                        slack.slackId,
+                        slack.receiverSlackId,
                         slack.id.as("slackMessageId"),
                         slack.message,
                         slack.createdAt.as("receivedAt")
@@ -50,7 +49,6 @@ public class SlackPageRepositoryImpl implements SlackPageRepository {
         return new PageImpl<>(results, pageable, total);
     }
 
-    // 검색 조건 생성
     private BooleanExpression getSearchPredicate(SlackSearchType searchType, String searchValue) {
 
         if (searchType == null || searchValue == null) {
@@ -58,7 +56,7 @@ public class SlackPageRepositoryImpl implements SlackPageRepository {
         }
 
         return switch (searchType) {
-            case SLACK_ID -> slack.slackId.containsIgnoreCase(searchValue);
+            case SLACK_ID -> slack.receiverSlackId.eq(searchValue);
             case MESSAGE_CONTENT -> slack.message.containsIgnoreCase(searchValue);
         };
     }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/SlackController.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/SlackController.java
@@ -14,7 +14,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,18 +25,9 @@ public class SlackController {
 
     private final SlackService slackService;
 
-    // TODO: Slack WebHook 연동
-//    @PostMapping
-//    public CommonResponse<SlackResponse> sendSlackMessage(
-//    }
-
-
-    // FIXME: Slack App에서 보내는 메시지를 받아야 합니다. 현재는 임시로 구현되어 있습니다.
-    @PostMapping("/events")
-    public CommonResponse<SlackResponse> receiveSlackMessage(
-            @Valid @RequestBody SlackSendMessageRequest request,
-            @RequestHeader("X-UserId") String userId) {
-        return CommonResponse.success(slackService.saveSlackMessage(request.toDto(userId)));
+    @PostMapping
+    public CommonResponse<SlackResponse> sendSlackMessage(@Valid @RequestBody SlackSendMessageRequest request){
+        return CommonResponse.success(slackService.sendSlackMessage(request.toDto()));
     }
 
     @GetMapping

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/SlackSendMessageRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/SlackSendMessageRequest.java
@@ -1,19 +1,18 @@
 package com.sparta.ch4.delivery.user.presentation.request;
 
-import com.sparta.ch4.delivery.user.application.dto.SlackMessageDto;
+import com.sparta.ch4.delivery.user.application.dto.SlackSendMessageDto;
 import jakarta.validation.constraints.NotBlank;
 
 public record SlackSendMessageRequest (
         @NotBlank(message = "사용자 Slack 아이디는 필수입니다.")
-        String userSlackId,
+        String receiverSlackId,
 
         @NotBlank(message = "메시지는 내용은 필수입니다.")
         String message
 ) {
-    public SlackMessageDto toDto(String userId) {
-        return SlackMessageDto.builder()
-                .userSlackId(userSlackId)
-                .userId(Long.valueOf(userId))
+    public SlackSendMessageDto toDto() {
+        return SlackSendMessageDto.builder()
+                .receiverSlackId(receiverSlackId)
                 .message(message)
                 .build();
     }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/SlackResponse.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/response/SlackResponse.java
@@ -7,16 +7,14 @@ import lombok.Builder;
 
 @Builder
 public record SlackResponse(
-        Long userId,
-        String userSlackId,
+        String receiverSlackId,
         UUID slackMessageId,
         String message,
         LocalDateTime receivedAt
 ) {
     public static SlackResponse fromSlackMessageDto(SlackMessageDto dto) {
         return SlackResponse.builder()
-                .userId(dto.userId())
-                .userSlackId(dto.userSlackId())
+                .receiverSlackId(dto.receiverSlackId())
                 .slackMessageId(dto.slackMessageId())
                 .message(dto.message())
                 .receivedAt(dto.receivedAt())

--- a/user/src/main/resources/application-dev.yml
+++ b/user/src/main/resources/application-dev.yml
@@ -27,3 +27,6 @@ eureka:
 jwt:
   secret-key: ${JWT_SECRET_KEY}
   expiration-time: ${JWT_EXPIRATION_TIME}
+
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL}

--- a/user/src/main/resources/application-local.yml
+++ b/user/src/main/resources/application-local.yml
@@ -30,3 +30,6 @@ eureka:
 jwt:
   secret-key: ${JWT_SECRET_KEY}
   expiration-time: ${JWT_EXPIRATION_TIME}
+
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL}


### PR DESCRIPTION
close #33 

### 구현 내용
- slack과 연동하여, `POST http://localhost:19091/api/slack` 로 
```json
{
  "receiverSlackId": "슬랙아이디",
  "message": "Hello, this is a test message!"
}
```
를 body에 넣어서 보내면 아래와 같이 문자가 옵니다.
![image](https://github.com/user-attachments/assets/b4e551e6-0511-4774-8439-19fff623c114)

### 수정 사항
- Slack 엔티티는 삭제, 수정을 안 한다는 가정으로 BaseTimeEntity를 상속하지 않았습니다.
- Slack과 User 매핑을 제거하고, Slack은 **User 서버를 통해 Slack으로 보낸 메시지를 저장하는 역할로 설정했습니다.**
- 그래서 메시지를 받는 사람의 슬랙 아이디, 메시지, 보낸 시간만 저장하도록 했습니다.