### PR TITLE
Feat: Docker compose 작성 , Redis, 모니터링 컨테이너 추가

### DIFF
--- a/build-docker-compose.sh
+++ b/build-docker-compose.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+COMPOSE_DIR="./docker"
+
+COMPOSE_FILES=(
+    "docker-compose.network.yml"
+    "docker-compose.company.yml"
+    "docker-compose.order.yml"
+    "docker-compose.user.yml"
+    "docker-compose.gateway.yml"
+    "docker-compose.eureka.yml"
+    "docker-compose.hub.yml"
+)
+
+for compose_file in "${COMPOSE_FILES[@]}"; do
+    echo "Building and starting services from $compose_file"
+    docker-compose -f "$COMPOSE_DIR/$compose_file" up --build -d
+done
+
+echo "All services have been built and started."

--- a/build-docker-compose.sh
+++ b/build-docker-compose.sh
@@ -4,6 +4,7 @@ COMPOSE_DIR="./docker"
 
 COMPOSE_FILES=(
     "docker-compose.network.yml"
+    "docker-compose.cache.yml"
     "docker-compose.company.yml"
     "docker-compose.order.yml"
     "docker-compose.user.yml"

--- a/company/src/main/resources/application-dev.yml
+++ b/company/src/main/resources/application-dev.yml
@@ -4,7 +4,13 @@ spring:
   config:
     activate:
       on-profile: dev
-  #docker에서 DB 환경변수를 넣어주기
+
+  datasource:
+    url: ${COMPANY_SERVER_DB_URL}
+    username: ${COMPANY_SERVER_DB_USERNAME}
+    password: ${COMPANY_SERVER_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
   jpa:
     hibernate:
       ddl-auto: create

--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -1,0 +1,28 @@
+global:
+  scrape_interval: 15s  # How often to scrape targets (default is every 15 seconds)
+  evaluation_interval: 15s  # How often to evaluate rules (default is every 15 seconds)
+  external_labels:
+    monitor: 'delivery-monitor'
+
+scrape_configs:
+  # Scrape Prometheus' own metrics
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: [ 'localhost:9090' ]  # Prometheus itself is running on port 9090
+
+  # Example scrape configuration for a Docker-based service
+  - job_name: 'docker-services'
+    static_configs:
+      - targets:
+          - 'gateway-app:18080'  # Gateway app container
+          - 'order-app:19094'    # Order app container
+          - 'user-app:19091'     # User app container
+          - 'hub-app:19093'      # Hub app container
+          - 'company-app:19092'      # Hub app container
+          - 'eureka-app:19090'      # Hub app container
+
+  - job_name: 'monitor-services'
+    static_configs:
+      - targets:
+          - 'zipkin:9411'
+          - 'grafana:3000'

--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -18,8 +18,8 @@ scrape_configs:
           - 'order-app:19094'    # Order app container
           - 'user-app:19091'     # User app container
           - 'hub-app:19093'      # Hub app container
-          - 'company-app:19092'      # Hub app container
-          - 'eureka-app:19090'      # Hub app container
+          - 'company-app:19092'      # Company app container
+          - 'eureka-app:19090'      # Eureka app container
 
   - job_name: 'monitor-services'
     static_configs:

--- a/docker/docker-compose.cache.yml
+++ b/docker/docker-compose.cache.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  redis-db:
+    image: redis:7.4
+    container_name: redis-db
+    ports:
+      - "${REDIS_PORT}:${REDIS_PORT}"
+
+#networks:
+#  service-network:
+#    external: true

--- a/docker/docker-compose.company.yml
+++ b/docker/docker-compose.company.yml
@@ -16,7 +16,7 @@ services:
   company-app:
     container_name: company-app
     build:
-      context: .
+      context: ../company
       dockerfile: Dockerfile
     depends_on:
       - company-db

--- a/docker/docker-compose.company.yml
+++ b/docker/docker-compose.company.yml
@@ -1,6 +1,6 @@
 services:
   company-db:
-    image: postgres:latest
+    image: postgres:16.4
     container_name: company-db
     environment:
       POSTGRES_USER: ${COMPANY_SERVER_DB_USERNAME}
@@ -11,7 +11,7 @@ services:
     volumes:
       - postgres-data:${COMPANY_SERVER_DB_VOLUMES}
     networks:
-      - delivery-msa-net
+      - service-network
 
   company-app:
     container_name: company-app
@@ -24,7 +24,7 @@ services:
     ports:
       - "${COMPANY_SERVER_PORT}:${COMPANY_SERVER_PORT}"
     networks:
-      - delivery-msa-net
+      - service-network
     environment:
       SPRING_DATASOURCE_URL: ${COMPANY_SERVER_DB_URL}
       SPRING_DATASOURCE_USERNAME: ${COMPANY_SERVER_DB_USERNAME}
@@ -34,7 +34,7 @@ services:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
 
 networks:
-  delivery-msa-net:
+  service-network:
     external: true
 
 volumes:

--- a/docker/docker-compose.eureka.yml
+++ b/docker/docker-compose.eureka.yml
@@ -8,11 +8,11 @@ services:
     ports:
       - "${EUREKA_SERVER_PORT}:${EUREKA_SERVER_PORT}"
     networks:
-      - delivery-msa-net
+      - service-network
     environment:
       EUREKA_SERVER_PORT: ${EUREKA_SERVER_PORT}
       EUREKA_SERVER_HOST: ${EUREKA_SERVER_HOST}
 
 networks:
-  delivery-msa-net:
+  service-network:
     external: true

--- a/docker/docker-compose.eureka.yml
+++ b/docker/docker-compose.eureka.yml
@@ -1,0 +1,18 @@
+services:
+  eureka-app:
+    container_name: eureka-app
+    build:
+      context: ../eureka
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - "${EUREKA_SERVER_PORT}:${EUREKA_SERVER_PORT}"
+    networks:
+      - delivery-msa-net
+    environment:
+      EUREKA_SERVER_PORT: ${EUREKA_SERVER_PORT}
+      EUREKA_SERVER_HOST: ${EUREKA_SERVER_HOST}
+
+networks:
+  delivery-msa-net:
+    external: true

--- a/docker/docker-compose.gateway.yml
+++ b/docker/docker-compose.gateway.yml
@@ -1,33 +1,40 @@
+version: '3.8'
 services:
   gateway-app:
     container_name: gateway-app
     build:
-      context: .
+      context: ../gateway
       dockerfile: Dockerfile
     restart: always
     ports:
       - "${GATEWAY_SERVER_PORT}:${GATEWAY_SERVER_PORT}"
     networks:
-      - delivery-msa-net
+      - client-network
+      - app-network
+      - monitoring-network
     environment:
       GATEWAY_SERVER_PORT: ${GATEWAY_SERVER_PORT}
       GATEWAY_SERVER_HOST: ${GATEWAY_SERVER_HOST}
 
       HUB_SERVER_PORT: ${HUB_SERVER_PORT}
-      HUB_SERVER_HOST: ${HUB_SERVER_HOST}
+      HUB_SERVER_HOST: ${HUB_SERVER_CONTAINER_NAME}
 
       USER_SERVER_PORT: ${USER_SERVER_PORT}
-      USER_SERVER_HOST: ${USER_SERVER_HOST}
+      USER_SERVER_HOST: ${USER_SERVER_CONTAINER_NAME}
 
       COMPANY_SERVER_PORT: ${COMPANY_SERVER_PORT}
-      COMPANY_SERVER_HOST: ${COMPANY_SERVER_HOST}
+      COMPANY_SERVER_HOST: ${COMPANY_SERVER_CONTAINER_NAME}
 
       ORDER_SERVER_PORT: ${ORDER_SERVER_PORT}
-      ORDER_SERVER_HOST: ${ORDER_SERVER_HOST}
+      ORDER_SERVER_HOST: ${ORDER_SERVER_CONTAINER_NAME}
 
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
 
 networks:
-  delivery-msa-net:
+  gateway-network:
+    external: true
+  app-network:
+    external: true
+  monitoring-network:
     external: true

--- a/docker/docker-compose.gateway.yml
+++ b/docker/docker-compose.gateway.yml
@@ -9,8 +9,8 @@ services:
     ports:
       - "${GATEWAY_SERVER_PORT}:${GATEWAY_SERVER_PORT}"
     networks:
-      - client-network
-      - app-network
+      - gateway-network
+      - service-network
       - monitoring-network
     environment:
       GATEWAY_SERVER_PORT: ${GATEWAY_SERVER_PORT}
@@ -34,7 +34,7 @@ services:
 networks:
   gateway-network:
     external: true
-  app-network:
+  service-network:
     external: true
   monitoring-network:
     external: true

--- a/docker/docker-compose.hub.yml
+++ b/docker/docker-compose.hub.yml
@@ -1,3 +1,4 @@
+version: '3.8'
 services:
   hub-db:
     image: postgres:16.4
@@ -11,12 +12,12 @@ services:
     volumes:
       - postgres-data:${HUB_SERVER_DB_VOLUMES}
     networks:
-      - delivery-msa-net
+      - internal-network
 
   hub-app:
     container_name: hub-app
     build:
-      context: .
+      context: ../hub
       dockerfile: Dockerfile
     depends_on:
       - hub-db
@@ -24,18 +25,15 @@ services:
     ports:
       - "${HUB_SERVER_PORT}:${HUB_SERVER_PORT}"
     networks:
-      - delivery-msa-net
+      - internal-network
     environment:
       SPRING_DATASOURCE_URL: ${HUB_SERVER_DB_URL}
       SPRING_DATASOURCE_USERNAME: ${HUB_SERVER_DB_USERNAME}
       SPRING_DATASOURCE_PASSWORD: ${HUB_SERVER_DB_PASSWORD}
-      HUB_SERVER_PORT: ${HUB_SERVER_PORT}
-      HUB_SERVER_HOST: ${HUB_SERVER_HOST}
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
 
 networks:
-  delivery-msa-net:
+  internal-network:
     external: true
-
 volumes:
   postgres-data:

--- a/docker/docker-compose.hub.yml
+++ b/docker/docker-compose.hub.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - postgres-data:${HUB_SERVER_DB_VOLUMES}
     networks:
-      - internal-network
+      - service-network
 
   hub-app:
     container_name: hub-app
@@ -25,7 +25,7 @@ services:
     ports:
       - "${HUB_SERVER_PORT}:${HUB_SERVER_PORT}"
     networks:
-      - internal-network
+      - service-network
     environment:
       SPRING_DATASOURCE_URL: ${HUB_SERVER_DB_URL}
       SPRING_DATASOURCE_USERNAME: ${HUB_SERVER_DB_USERNAME}
@@ -33,7 +33,7 @@ services:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
 
 networks:
-  internal-network:
+  service-network:
     external: true
 volumes:
   postgres-data:

--- a/docker/docker-compose.network.yml
+++ b/docker/docker-compose.network.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+networks:
+  gateway-network:
+    driver: bridge
+  internal-network:
+    driver: bridge
+    internal: true
+  monitoring-network:
+    driver: bridge

--- a/docker/docker-compose.network.yml
+++ b/docker/docker-compose.network.yml
@@ -2,7 +2,7 @@ version: '3.8'
 networks:
   gateway-network:
     driver: bridge
-  internal-network:
+  service-network:
     driver: bridge
     internal: true
   monitoring-network:

--- a/docker/docker-compose.order.yml
+++ b/docker/docker-compose.order.yml
@@ -1,3 +1,4 @@
+version: '3.8'
 services:
   order-db:
     image: postgres:16.4
@@ -11,12 +12,12 @@ services:
     volumes:
       - postgres-data:${ORDER_SERVER_DB_VOLUMES}
     networks:
-      - delivery-msa-net
+      - internal-network
 
   order-app:
     container_name: order-app
     build:
-      context: .
+      context: ../order
       dockerfile: Dockerfile
     depends_on:
       - order-db
@@ -24,7 +25,7 @@ services:
     ports:
       - "${ORDER_SERVER_PORT}:${ORDER_SERVER_PORT}"
     networks:
-      - delivery-msa-net
+      - internal-network
     environment:
       SPRING_DATASOURCE_URL: ${ORDER_SERVER_DB_URL}
       SPRING_DATASOURCE_USERNAME: ${ORDER_SERVER_DB_USERNAME}
@@ -34,8 +35,7 @@ services:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
 
 networks:
-  delivery-msa-net:
+  internal-network:
     external: true
-
 volumes:
   postgres-data:

--- a/docker/docker-compose.order.yml
+++ b/docker/docker-compose.order.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - postgres-data:${ORDER_SERVER_DB_VOLUMES}
     networks:
-      - internal-network
+      - service-network
 
   order-app:
     container_name: order-app
@@ -25,7 +25,7 @@ services:
     ports:
       - "${ORDER_SERVER_PORT}:${ORDER_SERVER_PORT}"
     networks:
-      - internal-network
+      - service-network
     environment:
       SPRING_DATASOURCE_URL: ${ORDER_SERVER_DB_URL}
       SPRING_DATASOURCE_USERNAME: ${ORDER_SERVER_DB_USERNAME}
@@ -35,7 +35,7 @@ services:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
 
 networks:
-  internal-network:
+  service-network:
     external: true
 volumes:
   postgres-data:

--- a/docker/docker-compose.user.yml
+++ b/docker/docker-compose.user.yml
@@ -11,12 +11,12 @@ services:
     volumes:
       - postgres-data:${USER_SERVER_DB_VOLUMES}
     networks:
-      - delivery-msa-net
+      - internal-network
 
   user-app:
     container_name: user-app
     build:
-      context: .
+      context: ../user
       dockerfile: Dockerfile
     depends_on:
       - user-db
@@ -24,7 +24,7 @@ services:
     ports:
       - "${USER_SERVER_PORT}:${USER_SERVER_PORT}"
     networks:
-      - delivery-msa-net
+      - internal-network
     environment:
       SPRING_DATASOURCE_URL: ${USER_SERVER_DB_URL}
       SPRING_DATASOURCE_USERNAME: ${USER_SERVER_DB_USERNAME}
@@ -37,7 +37,7 @@ services:
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
 
 networks:
-  delivery-msa-net:
+  internal-network:
     external: true
 
 volumes:

--- a/docker/docker-compose.user.yml
+++ b/docker/docker-compose.user.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - postgres-data:${USER_SERVER_DB_VOLUMES}
     networks:
-      - internal-network
+      - service-network
 
   user-app:
     container_name: user-app
@@ -24,7 +24,7 @@ services:
     ports:
       - "${USER_SERVER_PORT}:${USER_SERVER_PORT}"
     networks:
-      - internal-network
+      - service-network
     environment:
       SPRING_DATASOURCE_URL: ${USER_SERVER_DB_URL}
       SPRING_DATASOURCE_USERNAME: ${USER_SERVER_DB_USERNAME}
@@ -37,7 +37,7 @@ services:
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
 
 networks:
-  internal-network:
+  service-network:
     external: true
 
 volumes:

--- a/docker/docker.compose.monitor.yml
+++ b/docker/docker.compose.monitor.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  zipkin:
+    image: openzipkin/zipkin
+    ports:
+      - "9411:9411"
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/docker/docker.compose.monitor.yml
+++ b/docker/docker.compose.monitor.yml
@@ -8,7 +8,7 @@ services:
   prometheus:
     image: prom/prometheus
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ../config/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"
 

--- a/eureka/Dockerfile
+++ b/eureka/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:17-jdk-alpine
+
+CMD ["./gradlew", "clean", "build", "-x", "test"]
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} eureka-app.jar
+
+ENTRYPOINT ["java","-jar","/eureka-app.jar"]

--- a/eureka/src/main/resources/application-dev.yml
+++ b/eureka/src/main/resources/application-dev.yml
@@ -3,11 +3,11 @@ spring:
     name: eureka
 
 server:
-  port: ${EUREKA_PORT}
+  port: ${EUREKA_SERVER_PORT}
 
 eureka:
   instance:
-    hostname: ${EUREKA_HOST}
+    hostname: ${EUREKA_SERVER_HOST}
   client:
     registerWithEureka: false
     fetchRegistry: false

--- a/eureka/src/main/resources/application-prod.yml
+++ b/eureka/src/main/resources/application-prod.yml
@@ -3,11 +3,11 @@ spring:
     name: eureka
 
 server:
-  port: ${EUREKA_PORT}
+  port: ${EUREKA_SERVER_PORT}
 
 eureka:
   instance:
-    hostname: ${EUREKA_HOST}
+    hostname: ${EUREKA_SERVER_HOST}
   client:
     registerWithEureka: false
     fetchRegistry: false

--- a/hub/src/main/resources/application-dev.yml
+++ b/hub/src/main/resources/application-dev.yml
@@ -4,7 +4,13 @@ spring:
   config:
     activate:
       on-profile: dev
-  #docker에서 DB 환경변수를 넣어주기
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ${HUB_SERVER_DB_URL}
+    username: ${HUB_SERVER_DB_USERNAME}
+    password: ${HUB_SERVER_DB_PASSWORD}
+
   jpa:
     hibernate:
       ddl-auto: create

--- a/hub/src/main/resources/application-local.yml
+++ b/hub/src/main/resources/application-local.yml
@@ -5,9 +5,9 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:postgresql://localhost:5433/hubdelivery
-    username: postgres
-    password: ${DB_SECRET}
+    url: ${HUB_SERVER_DB_URL}
+    username: ${HUB_SERVER_DB_USERNAME}
+    password: ${HUB_SERVER_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 #    driver-class-name: org.h2.Driver
 #    url: 'jdbc:h2:mem:test'

--- a/order/src/main/resources/application-dev.yml
+++ b/order/src/main/resources/application-dev.yml
@@ -4,7 +4,13 @@ spring:
   config:
     activate:
       on-profile: dev
-  #docker에서 DB 환경변수를 넣어주기
+
+  datasource:
+    url: ${ORDER_SERVER_DB_URL}
+    username: ${ORDER_SERVER_DB_USERNAME}
+    password: ${ORDER_SERVER_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
   jpa:
     hibernate:
       ddl-auto: create

--- a/user/src/main/resources/application-dev.yml
+++ b/user/src/main/resources/application-dev.yml
@@ -5,6 +5,12 @@ spring:
     activate:
       on-profile: dev
 
+  datasource:
+    url: ${USER_SERVER_DB_URL}
+    username: ${USER_SERVER_DB_USERNAME}
+    password: ${USER_SERVER_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
close #40 

**_application 프로필 수정에 따라 Conflict가 날 수 있습니다._**

## 주요 사항
- `/docker` 를 만들어서 compose 파일들을 모아놨습니다.
- 한 번에 build 가능하도록 shell 스크립트를 작성했습니다.
- **Redis를 `docker-compose.cache.yml`에 추가하였습니다.** 테스트하기 쉽게 network 는 설정하지 않았습니다.
- `.env`는 업데이트해서 구글 드라이브에 업로드 해놓았습니다.
- prometheus, grafana, zipkin을 `docker-compose.monitor.yml`에 일단 만들어놨는데, 각 서비스별로 추가적으로 설정이 필요하여 추후 필수 기능이 완료되면 추가하면 될 것 같습니다. 
- `/config`에 prometheus 설정 파일을 추가했는데 아직 세세한 설정은 되어있지 않습니다..!
- 기존 서비스에 `application-dev.yml`에 없었던 datasource 설정을 추가했습니다.

## Docker 네트워크 
`docker-compose.network.yml`에 세 가지 네트워크가 있습니다.
monitoring, gateway-network는 외부 접근이 가능하지만, `service-network`는 외부 접근을 막도록 구성했습니다.

> internal: true: 네트워크를 내부 전용으로 설정하여 외부 접근을 차단합니다.
> 각 서비스에서 network: 네트워크명: external: true -> docker engine에 있는 network를 참조