### PR TITLE
Feat: User 서버에 Swagger 설정 추가 및 예외 처리 핸들러 구현

### DIFF
--- a/user/build.gradle
+++ b/user/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/service/AuthService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/service/AuthService.java
@@ -2,12 +2,13 @@ package com.sparta.ch4.delivery.user.application.service;
 
 import com.sparta.ch4.delivery.user.application.dto.LoginDto;
 import com.sparta.ch4.delivery.user.application.dto.RegisterDto;
+import com.sparta.ch4.delivery.user.domain.exception.ApplicationException;
+import com.sparta.ch4.delivery.user.domain.exception.ErrorCode;
 import com.sparta.ch4.delivery.user.domain.model.User;
 import com.sparta.ch4.delivery.user.domain.repository.UserRepository;
 import com.sparta.ch4.delivery.user.domain.service.UserDomainService;
 import com.sparta.ch4.delivery.user.infrastructure.jwt.JwtTokenProvider;
 import com.sparta.ch4.delivery.user.presentation.response.UserResponse;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -34,7 +35,7 @@ public class AuthService {
     @Transactional(readOnly = true)
     public UserResponse login(HttpServletResponse response, LoginDto dto) {
         User user = userRepository.findByUsername(dto.username())
-                .orElseThrow(() -> new EntityNotFoundException("Username 에 해당하는 사용자가 없습니다."));
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USERNAME_NOT_FOUND));
         checkPassword(dto.password(), user.getPassword());
 
         String token = jwtTokenProvider.createToken(user.getId(), user.getUsername(), user.getRole());
@@ -45,7 +46,7 @@ public class AuthService {
 
     private void checkPassword(String inputPassword, String userPassword) {
         if (!passwordEncoder.matches(inputPassword, userPassword)) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new ApplicationException(ErrorCode.PASSWORD_MISMATCH);
         }
     }
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/application/service/SlackService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/application/service/SlackService.java
@@ -5,41 +5,16 @@ import com.sparta.ch4.delivery.user.domain.service.SlackDomainService;
 import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
 import com.sparta.ch4.delivery.user.presentation.response.SlackResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
 public class SlackService {
 
     private final SlackDomainService slackDomainService;
-
-    @Value("${slack.webhook-url}")
-    private String webhookUrl;
-
-    @Transactional
-    public SlackResponse sendSlackMessage(SlackSendMessageDto dto) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Content-Type", "application/json");
-        String payload = getPayload(dto.receiverSlackId(), dto.message());
-        HttpEntity<String> request = new HttpEntity<>(payload, headers);
-
-        RestTemplate restTemplate = new RestTemplate();
-        try {
-            restTemplate.exchange(webhookUrl, HttpMethod.POST, request, String.class);
-        } catch (RestClientException e) {
-            throw new RestClientException("Slack 메시지 전송 중 에러가 발생했습니다.");
-        }
-        return saveSlackMessage(dto);
-    }
 
     public SlackResponse saveSlackMessage(SlackSendMessageDto dto) {
         return SlackResponse.fromSlackMessageDto(slackDomainService.saveSlackMessage(dto));
@@ -49,16 +24,6 @@ public class SlackService {
     public Page<SlackResponse> getSlackMessages(
             SlackSearchType searchType, String searchValue, Pageable pageable) {
         return slackDomainService.getSlackMessages(searchType, searchValue, pageable).map(SlackResponse::fromSlackMessageDto);
-    }
-
-    private String getPayload(String recipientSlackId, String message) {
-        return String.format("""
-                {
-                    "channel": "@%s",
-                    "username": "IS20bot",
-                    "text": "%s"
-                }
-                """, recipientSlackId, message);
     }
 
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/exception/ApplicationException.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/exception/ApplicationException.java
@@ -1,0 +1,14 @@
+package com.sparta.ch4.delivery.user.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public ApplicationException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.message = errorCode.getMessage();
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/exception/ErrorCode.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.sparta.ch4.delivery.user.domain.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "ID 에 해당하는 사용자가 존재하지 않습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    USERNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자 이름입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    USERNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 아이디에 해당하는 사용자가 없습니다."),
+    SLACK_SEND_MESSAGE_FAIL(HttpStatus.BAD_REQUEST, "Slack 메시지 전송 중 문제가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/exception/ErrorResponse.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/exception/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.sparta.ch4.delivery.user.domain.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse<T> {
+    private HttpStatus status;
+    private String message;
+
+    public static <T> ErrorResponse<T> error(ErrorCode errorCode) {
+        return new ErrorResponse<>(errorCode.getStatus(), errorCode.getMessage());
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/exception/ExceptionManager.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/exception/ExceptionManager.java
@@ -1,0 +1,16 @@
+package com.sparta.ch4.delivery.user.domain.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionManager {
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ErrorResponse<?>> applicationExceptionHandler(ApplicationException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.error(e.getErrorCode()));
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/UserDomainService.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/domain/service/UserDomainService.java
@@ -4,11 +4,12 @@ import com.sparta.ch4.delivery.user.application.dto.RegisterDto;
 import com.sparta.ch4.delivery.user.application.dto.UserDto;
 import com.sparta.ch4.delivery.user.application.dto.UserPageDto;
 import com.sparta.ch4.delivery.user.application.dto.UserUpdateDto;
+import com.sparta.ch4.delivery.user.domain.exception.ApplicationException;
+import com.sparta.ch4.delivery.user.domain.exception.ErrorCode;
 import com.sparta.ch4.delivery.user.domain.model.User;
 import com.sparta.ch4.delivery.user.domain.repository.UserPageRepository;
 import com.sparta.ch4.delivery.user.domain.repository.UserRepository;
 import com.sparta.ch4.delivery.user.domain.type.UserSearchType;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +37,7 @@ public class UserDomainService {
 
     public UserDto getUserById(Long userId) {
        return userRepository.findById(userId).map(UserDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
     }
 
     public Page<UserPageDto> getUsers(UserSearchType searchType, String searchValue, Pageable pageable) {
@@ -45,7 +46,7 @@ public class UserDomainService {
 
     public UserDto updateUser(Long userId, UserUpdateDto dto) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
         String password = passwordEncoder.encode(dto.password());
         user.update(dto, password);
         return UserDto.from(userRepository.save(user));
@@ -53,17 +54,17 @@ public class UserDomainService {
 
     public void deleteUserById(Long userId, String deleteBy) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("ID 에 해당하는 사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
         user.delete(deleteBy);
         userRepository.save(user);
     }
 
     private void checkDuplicate(String username, String email) {
         if (userRepository.existsByUsername(username)) {
-            throw new IllegalArgumentException("이미 존재하는 사용자 이름입니다.");
+            throw new ApplicationException(ErrorCode.USERNAME_ALREADY_EXISTS);
         }
         if (userRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+            throw new ApplicationException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
     }
 

--- a/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/client/SlackMessageClient.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/infrastructure/client/SlackMessageClient.java
@@ -1,0 +1,53 @@
+package com.sparta.ch4.delivery.user.infrastructure.client;
+
+import com.sparta.ch4.delivery.user.application.dto.SlackSendMessageDto;
+import com.sparta.ch4.delivery.user.application.service.SlackService;
+import com.sparta.ch4.delivery.user.domain.exception.ApplicationException;
+import com.sparta.ch4.delivery.user.domain.exception.ErrorCode;
+import com.sparta.ch4.delivery.user.presentation.response.SlackResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class SlackMessageClient {
+
+    private final SlackService slackService;
+
+    @Value("${slack.webhook-url}")
+    private String webhookUrl;
+
+    @Transactional
+    public SlackResponse sendSlackMessage(SlackSendMessageDto dto) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        String payload = createSlackPayload(dto.receiverSlackId(), dto.message());
+        HttpEntity<String> request = new HttpEntity<>(payload, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            restTemplate.exchange(webhookUrl, HttpMethod.POST, request, String.class);
+        } catch (RestClientException e) {
+            throw new ApplicationException(ErrorCode.SLACK_SEND_MESSAGE_FAIL);
+        }
+        return slackService.saveSlackMessage(dto);
+    }
+
+    public String createSlackPayload(String recipientSlackId, String message) {
+        return String.format("""
+                {
+                    "channel": "@%s",
+                    "username": "IS20bot",
+                    "text": "%s"
+                }
+                """, recipientSlackId, message);
+    }
+
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/config/SwaggerConfig.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.sparta.ch4.delivery.user.presentation.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customizeOpenAPI() {
+        Info info = new Info()
+                .title("DeliveryProject")
+                .description("✨ MSA를 통한 허브 물류 관리 시스템 ✨");
+        return new OpenAPI()
+                .info(info);
+    }
+}

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/AuthController.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/AuthController.java
@@ -5,6 +5,10 @@ import com.sparta.ch4.delivery.user.presentation.request.LoginRequest;
 import com.sparta.ch4.delivery.user.presentation.request.RegisterRequest;
 import com.sparta.ch4.delivery.user.presentation.response.CommonResponse;
 import com.sparta.ch4.delivery.user.presentation.response.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,20 +20,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth Controller", description = "사용자 인증 및 회원가입을 처리하는 API입니다.")
 public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+    @ApiResponse(responseCode = "200", description = "회원가입이 성공적으로 완료되었습니다.")
     @PostMapping("/register")
     public CommonResponse<UserResponse> register(
-            @Valid @RequestBody RegisterRequest request) {
+            @Parameter(description = "회원가입 요청 데이터") @Valid @RequestBody RegisterRequest request) {
         return CommonResponse.success(authService.register(request.toDto()));
     }
 
+    @Operation(summary = "로그인", description = "사용자 로그인 처리를 합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인이 성공적으로 완료되었습니다.")
+    @ApiResponse(responseCode = "404", description = "사용자 아이디에 해당하는 사용자가 없습니다.")
+    @ApiResponse(responseCode = "401", description = "비밀번호가 일치하지 않습니다.")
     @PostMapping("/login")
-    public CommonResponse<UserResponse> login(HttpServletResponse response, @RequestBody LoginRequest request) {
+    public CommonResponse<UserResponse> login(
+            @Parameter(description = "로그인 요청 데이터") @RequestBody LoginRequest request,
+            @Parameter(description = "응답 헤더") HttpServletResponse response) {
         return CommonResponse.success(authService.login(response, request.toDto()));
     }
 
     // TODO 도전 기능: 비밀번호 초기화
 }
+

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/SlackController.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/SlackController.java
@@ -2,9 +2,14 @@ package com.sparta.ch4.delivery.user.presentation.controller;
 
 import com.sparta.ch4.delivery.user.application.service.SlackService;
 import com.sparta.ch4.delivery.user.domain.type.SlackSearchType;
+import com.sparta.ch4.delivery.user.infrastructure.client.SlackMessageClient;
 import com.sparta.ch4.delivery.user.presentation.request.SlackSendMessageRequest;
 import com.sparta.ch4.delivery.user.presentation.response.CommonResponse;
 import com.sparta.ch4.delivery.user.presentation.response.SlackResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,23 +26,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/slack")
 @RequiredArgsConstructor
+@Tag(name = "Slack Controller", description = "Slack 메시지를 관리하는 API입니다.")
 public class SlackController {
 
     private final SlackService slackService;
+    private final SlackMessageClient slackMessageClient;
 
+    @Operation(summary = "슬랙 메시지 전송", description = "지정된 사용자에게 슬랙 메시지를 전송합니다.")
+    @ApiResponse(responseCode = "200", description = "메시지가 성공적으로 전송되었습니다.")
+    @ApiResponse(responseCode = "400", description = "Slack 메시지 전송 중 문제가 발생했습니다.")
     @PostMapping
-    public CommonResponse<SlackResponse> sendSlackMessage(@Valid @RequestBody SlackSendMessageRequest request){
-        return CommonResponse.success(slackService.sendSlackMessage(request.toDto()));
+    public CommonResponse<SlackResponse> sendSlackMessage(
+            @Parameter(description = "슬랙 메시지 요청 데이터") @Valid @RequestBody SlackSendMessageRequest request) {
+        return CommonResponse.success(slackMessageClient.sendSlackMessage(request.toDto()));
     }
 
+    @Operation(summary = "모든 슬랙 메시지 조회", description = "옵션으로 검색 조건을 사용하여 슬랙 메시지 목록을 페이지로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "슬랙 메시지가 성공적으로 조회되었습니다.")
     @GetMapping
     public CommonResponse<Page<SlackResponse>> getAllSlackMessages(
-            @RequestParam(required = false, name = "searchType") SlackSearchType searchType,
-            @RequestParam(required = false, name = "searchValue") String searchValue,
-            @PageableDefault(
+            @Parameter(description = "검색할 유형", example = "SLACK_ID") @RequestParam(required = false, name = "searchType") SlackSearchType searchType,
+            @Parameter(description = "검색 값") @RequestParam(required = false, name = "searchValue") String searchValue,
+            @Parameter(description = "페이지네이션 및 정렬 정보") @PageableDefault(
                     size = 10, sort = {"createdAt", "updatedAt"}, direction = Sort.Direction.DESC
             ) Pageable pageable) {
         return CommonResponse.success(slackService.getSlackMessages(searchType, searchValue, pageable));
     }
-
 }

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/controller/UserController.java
@@ -5,6 +5,10 @@ import com.sparta.ch4.delivery.user.domain.type.UserSearchType;
 import com.sparta.ch4.delivery.user.presentation.request.UserUpdateRequest;
 import com.sparta.ch4.delivery.user.presentation.response.CommonResponse;
 import com.sparta.ch4.delivery.user.presentation.response.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -12,52 +16,56 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@Tag(name = "User Controller", description = "사용자 관리를 위한 API입니다.")
 public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "사용자 ID로 사용자 조회", description = "특정 사용자 ID를 사용하여 사용자의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "사용자 정보가 성공적으로 조회되었습니다.")
+    @ApiResponse(responseCode = "404", description = "ID 에 해당하는 사용자가 존재하지 않습니다.")
     @GetMapping("/{userId}")
-    public CommonResponse<UserResponse> getUser(@PathVariable Long userId) {
+    public CommonResponse<UserResponse> getUser(
+            @Parameter(description = "조회할 사용자 ID") @PathVariable Long userId) {
         return CommonResponse.success(userService.getUserById(userId));
     }
 
+    @Operation(summary = "사용자 목록 조회", description = "옵션으로 검색 조건을 사용하여 사용자 목록을 페이지로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "사용자 목록이 성공적으로 조회되었습니다.")
     @GetMapping
     public CommonResponse<Page<UserResponse>> getUsers(
-            @RequestParam(required = false, name = "searchType") UserSearchType searchType,
-            @RequestParam(required = false, name = "searchValue") String searchValue,
-            @PageableDefault(
+            @Parameter(description = "검색할 유형", example = "USERNAME") @RequestParam(required = false, name = "searchType") UserSearchType searchType,
+            @Parameter(description = "검색할 값") @RequestParam(required = false, name = "searchValue") String searchValue,
+            @Parameter(description = "페이지네이션 및 정렬 정보") @PageableDefault(
                     size = 10, sort = {"createdAt", "updatedAt"}, direction = Sort.Direction.DESC
             ) Pageable pageable) {
         return CommonResponse.success(userService.getUsers(searchType, searchValue, pageable));
     }
 
+    @Operation(summary = "사용자 정보 수정", description = "특정 ID의 사용자의 정보를 업데이트합니다.")
+    @ApiResponse(responseCode = "200", description = "사용자 정보가 성공적으로 업데이트되었습니다.")
+    @ApiResponse(responseCode = "404", description = "ID 에 해당하는 사용자가 존재하지 않습니다.")
     @PutMapping("/{userId}")
     public CommonResponse<UserResponse> updateUser(
-            @RequestHeader("X-UserId") String updatedBy,
-            @PathVariable Long userId,
-            @Valid @RequestBody UserUpdateRequest updateUserRequest) {
+            @Parameter(description = "수정 작업을 수행하는 사용자 ID") @RequestHeader("X-UserId") String updatedBy,
+            @Parameter(description = "수정할 사용자 ID") @PathVariable Long userId,
+            @Parameter(description = "수정할 사용자 정보 요청 데이터") @Valid @RequestBody UserUpdateRequest updateUserRequest) {
         return CommonResponse.success(userService.updateUser(userId, updateUserRequest.toDto(updatedBy)));
     }
 
+    @Operation(summary = "사용자 삭제", description = "특정 ID의 사용자를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "사용자가 성공적으로 삭제되었습니다.")
+    @ApiResponse(responseCode = "404", description = "ID 에 해당하는 사용자가 존재하지 않습니다.")
     @DeleteMapping("/{userId}")
     @ResponseStatus(code = HttpStatus.NO_CONTENT)
     public void deleteUser(
-            @RequestHeader("X-UserId") String deleteBy,
-            @PathVariable Long userId) {
+            @Parameter(description = "삭제 작업을 수행하는 사용자 ID") @RequestHeader("X-UserId") String deleteBy,
+            @Parameter(description = "삭제할 사용자 ID") @PathVariable Long userId) {
         userService.deleteUser(userId, deleteBy);
     }
 

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/LoginRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/LoginRequest.java
@@ -4,17 +4,22 @@ import com.sparta.ch4.delivery.user.application.dto.LoginDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "로그인 요청 데이터")
 public record LoginRequest(
+
         @NotBlank(message = "사용자 이름은 필수입니다.")
         @Size(min = 4, max = 10, message = "사용자 이름은 4자에서 10자 사이여야 합니다.")
         @Pattern(regexp = "^[a-z0-9]+$", message = "사용자 이름은 소문자 알파벳과 숫자만 포함해야 합니다.")
+        @Schema(description = "사용자 이름, 소문자 알파벳과 숫자만 포함 가능", example = "user123")
         String username,
 
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자 사이여야 합니다.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).+$",
                 message = "비밀번호는 최소 한 개의 알파벳, 숫자, 특수 문자를 포함해야 합니다.")
+        @Schema(description = "비밀번호, 최소 하나의 알파벳, 숫자, 특수 문자를 포함", example = "Passw0rd!")
         String password
 ) {
         public LoginDto toDto() {
@@ -24,4 +29,3 @@ public record LoginRequest(
                         .build();
         }
 }
-

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/RegisterRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/RegisterRequest.java
@@ -7,32 +7,43 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
+@Schema(description = "회원가입 요청 데이터")
 public record RegisterRequest(
+
         @NotBlank(message = "사용자 이름은 필수입니다.")
         @Size(min = 4, max = 10, message = "사용자 이름은 4자에서 10자 사이여야 합니다.")
         @Pattern(regexp = "^[a-z0-9]+$", message = "사용자 이름은 소문자 알파벳과 숫자만 포함해야 합니다.")
+        @Schema(description = "사용자 이름, 소문자 알파벳과 숫자만 포함 가능", example = "user123")
         String username,
 
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "유효한 이메일 형식이어야 합니다.")
+        @Schema(description = "유효한 이메일 주소", example = "user@example.com")
         String email,
 
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자 사이여야 합니다.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).+$",
                 message = "비밀번호는 최소 한 개의 알파벳, 숫자, 특수 문자를 포함해야 합니다.")
+        @Schema(description = "비밀번호, 최소 하나의 알파벳, 숫자, 특수 문자를 포함", example = "Passw0rd!")
         String password,
 
         @NotNull(message = "역할은 필수입니다.")
+        @Schema(description = "사용자 역할", example = "HUB_MANAGER")
         UserRole role,
 
         @NotBlank(message = "Slack 아이디는 필수입니다.")
+        @Schema(description = "사용자의 Slack 아이디", example = "U12345678")
         String slackId,
 
+        @Schema(description = "허브 ID (선택)", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID hubId,
 
+        @Schema(description = "업체 ID (선택)", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID companyId
 ) {
         public RegisterDto toDto() {
@@ -47,5 +58,3 @@ public record RegisterRequest(
                         .build();
         }
 }
-
-

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/SlackSendMessageRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/SlackSendMessageRequest.java
@@ -2,12 +2,17 @@ package com.sparta.ch4.delivery.user.presentation.request;
 
 import com.sparta.ch4.delivery.user.application.dto.SlackSendMessageDto;
 import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "슬랙 메시지 전송 요청 데이터")
 public record SlackSendMessageRequest (
+
         @NotBlank(message = "사용자 Slack 아이디는 필수입니다.")
+        @Schema(description = "메시지를 받을 사용자의 Slack ID", example = "U12345678")
         String receiverSlackId,
 
-        @NotBlank(message = "메시지는 내용은 필수입니다.")
+        @NotBlank(message = "메시지 내용은 필수입니다.")
+        @Schema(description = "전송할 메시지 내용", example = "안녕하세요, 새로운 공지사항이 있습니다.")
         String message
 ) {
     public SlackSendMessageDto toDto() {
@@ -17,4 +22,3 @@ public record SlackSendMessageRequest (
                 .build();
     }
 }
-

--- a/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/UserUpdateRequest.java
+++ b/user/src/main/java/com/sparta/ch4/delivery/user/presentation/request/UserUpdateRequest.java
@@ -7,29 +7,39 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
+@Schema(description = "사용자 업데이트 요청 데이터")
 public record UserUpdateRequest(
+
         @NotBlank(message = "사용자 이름은 필수입니다.")
         @Size(min = 4, max = 10, message = "사용자 이름은 4자에서 10자 사이여야 합니다.")
         @Pattern(regexp = "^[a-z0-9]+$", message = "사용자 이름은 소문자 알파벳과 숫자만 포함해야 합니다.")
+        @Schema(description = "업데이트할 사용자 이름, 소문자 알파벳과 숫자만 포함 가능", example = "newuser123")
         String username,
 
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "유효한 이메일 형식이어야 합니다.")
+        @Schema(description = "업데이트할 유효한 이메일 주소", example = "newemail@example.com")
         String email,
 
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자 사이여야 합니다.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).+$",
                 message = "비밀번호는 최소 한 개의 알파벳, 숫자, 특수 문자를 포함해야 합니다.")
+        @Schema(description = "업데이트할 비밀번호, 최소 하나의 알파벳, 숫자, 특수 문자를 포함", example = "NewPassw0rd!")
         String password,
 
         @NotNull(message = "역할은 필수입니다.")
+        @Schema(description = "업데이트할 사용자 역할", example = "ADMIN")
         UserRole role,
 
+        @Schema(description = "업데이트할 허브 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID hubId,
 
+        @Schema(description = "업데이트할 업체 ID", example = "550e8400-e29b-41d4-a716-446655440001")
         UUID companyId
 ) {
     public UserUpdateDto toDto(String updatedBy) {


### PR DESCRIPTION
close #46 

## 구현 내용
- User 서버에 Swagger를 추가하고, 각 클래스에 Swagger 설명을 추가했습니다.
- Slack과 통신하는 로직을 따로 `infrastructure/SlackMessageClient`에 분리하였습니다.
- Exception을 Handle 하는 `ExceptionManager`를 추가했습니다.