### PR TITLE
Feat: Swagger Gateway 통합

### DIFF
--- a/company/src/main/resources/application-dev.yml
+++ b/company/src/main/resources/application-dev.yml
@@ -21,6 +21,12 @@ spring:
 server:
   port: ${COMPANY_SERVER_PORT}
 
+springdoc:
+  api-docs:
+    path: /companies/v3/api-docs
+  swagger-ui:
+    path: /companies/swagger-ui.html
+
 eureka:
   instance:
     hostname: ${COMPANY_SERVER_HOST}

--- a/company/src/main/resources/application-local.yml
+++ b/company/src/main/resources/application-local.yml
@@ -18,6 +18,12 @@ spring:
 server:
   port: ${COMPANY_SERVER_PORT}
 
+springdoc:
+  api-docs:
+    path: /companies/v3/api-docs
+  swagger-ui:
+    path: /companies/swagger-ui.html
+
 eureka:
   instance:
     hostname: ${COMPANY_SERVER_HOST}

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.6.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/gateway/src/main/java/com/sparta/ch4/delivery/gateway/config/SwaggerConfig.java
+++ b/gateway/src/main/java/com/sparta/ch4/delivery/gateway/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.sparta.ch4.delivery.gateway.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customizeOpenAPI() {
+        Info info = new Info()
+                .title("DeliveryProject")
+                .description("✨ MSA를 통한 허브 물류 관리 시스템 ✨");
+        return new OpenAPI()
+                .info(info);
+    }
+
+}

--- a/gateway/src/main/java/com/sparta/ch4/delivery/gateway/security/SecurityConfig.java
+++ b/gateway/src/main/java/com/sparta/ch4/delivery/gateway/security/SecurityConfig.java
@@ -24,6 +24,8 @@ public class SecurityConfig {
                 .authorizeExchange(exchanges -> exchanges
 
                         .pathMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
+                        // FIXME: swagger ui에 접근은 되는데 정보를 불러오려 하면 인증을 요구함
+//                        .pathMatchers("/v3/api-docs/**", "/swagger-ui.html", "/webjars/**").permitAll()
 
                         // 사용자 관련
                         .pathMatchers(HttpMethod.GET, "/api/users/{userId}")
@@ -127,7 +129,8 @@ public class SecurityConfig {
                         .hasRole("MASTER") // 허브이동관리 수정
                         .pathMatchers(HttpMethod.DELETE, "/api/hub-routes/{hubRouteId}")
                         .hasRole("MASTER") // 허브이동관리 삭제
-                        .anyExchange().authenticated()
+
+                        .anyExchange().permitAll() // Swagger를 위해 허용
                 );
         return http.build();
     }

--- a/gateway/src/main/resources/application-dev.yml
+++ b/gateway/src/main/resources/application-dev.yml
@@ -10,26 +10,40 @@ spring:
         - id: user
           uri: http://${USER_SERVER_HOST}:${USER_SERVER_PORT}
           predicates:
-            - Path=/api/users/**, /api/auth/**
+            - Path=/api/users/**, /api/auth/**, /users/v3/api-docs
 
         - id: company
           uri: http://${COMPANY_SERVER_HOST}:${COMPANY_SERVER_PORT}
           predicates:
-            - Path=/api/companies/**, /api/products/**
+            - Path=/api/companies/**, /api/products/**, /companies/v3/api-docs
 
         - id: hub
           uri: http://${HUB_SERVER_HOST}:${HUB_SERVER_HOST}
           predicates:
-            - Path=/api/hubs/**, /api/hub-routes/**, /api/delivery-managers/**
+            - Path=/api/hubs/**, /api/hub-routes/**, /hubs/v3/api-docs
 
         - id: order
           uri: http://${ORDER_SERVER_HOST}:${ORDER_SERVER_HOST}
           predicates:
-            - Path=/api/deliveries/**, /api/orders/**, /api/delivery-histories/**
+            - Path=/api/deliveries/**, /api/orders/**, /orders/v3/api-docs
 
 server:
   port: ${GATEWAY_SERVER_PORT}
 
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    urls:
+      - url: /users/v3/api-docs
+        name: User
+      - url: /companies/v3/api-docs
+        name: Company
+      - url: /hubs/v3/api-docs
+        name: Hub
+      - url: /orders/v3/api-docs
+        name: Order
 eureka:
   instance:
     hostname: ${GATEWAY_SERVER_HOST}

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -10,25 +10,40 @@ spring:
         - id: user
           uri: http://${USER_SERVER_HOST}:${USER_SERVER_PORT}
           predicates:
-            - Path=/api/users/**, /api/auth/**
+            - Path=/api/users/**, /api/auth/**, /users/v3/api-docs
 
         - id: company
           uri: http://${COMPANY_SERVER_HOST}:${COMPANY_SERVER_PORT}
           predicates:
-            - Path=/api/companies/**, /api/products/**
+            - Path=/api/companies/**, /api/products/**, /companies/v3/api-docs
 
         - id: hub
           uri: http://${HUB_SERVER_HOST}:${HUB_SERVER_HOST}
           predicates:
-            - Path=/api/hubs/**, /api/hub-routes/**, /api/delivery-managers/**
+            - Path=/api/hubs/**, /api/hub-routes/**, /hubs/v3/api-docs
 
         - id: order
           uri: http://${ORDER_SERVER_HOST}:${ORDER_SERVER_HOST}
           predicates:
-            - Path=/api/deliveries/**, /api/orders/**, /api/delivery-histories/**
+            - Path=/api/deliveries/**, /api/orders/**, /orders/v3/api-docs
 
 server:
   port: ${GATEWAY_SERVER_PORT}
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    urls:
+      - url: /users/v3/api-docs
+        name: User
+      - url: /companies/v3/api-docs
+        name: Company
+      - url: /hubs/v3/api-docs
+        name: Hub
+      - url: /orders/v3/api-docs
+        name: Order
 
 eureka:
   instance:

--- a/hub/src/main/resources/application-dev.yml
+++ b/hub/src/main/resources/application-dev.yml
@@ -21,6 +21,12 @@ spring:
 server:
   port: ${HUB_SERVER_PORT}
 
+springdoc:
+  api-docs:
+    path: /hubs/v3/api-docs
+  swagger-ui:
+    path: /hubs/swagger-ui.html
+
 eureka:
   instance:
     hostname: ${HUB_SERVER_HOST}

--- a/hub/src/main/resources/application-local.yml
+++ b/hub/src/main/resources/application-local.yml
@@ -22,6 +22,12 @@ spring:
 server:
   port: ${HUB_SERVER_PORT}
 
+springdoc:
+  api-docs:
+    path: /hubs/v3/api-docs
+  swagger-ui:
+    path: /hubs/swagger-ui.html
+
 eureka:
   instance:
     hostname: ${HUB_SERVER_HOST}

--- a/user/src/main/resources/application-dev.yml
+++ b/user/src/main/resources/application-dev.yml
@@ -21,6 +21,12 @@ spring:
 server:
   port: ${USER_SERVER_PORT}
 
+springdoc:
+  api-docs:
+    path: /users/v3/api-docs
+  swagger-ui:
+    path: /users/swagger-ui.html
+
 eureka:
   instance:
     hostname: ${USER_SERVER_HOST}

--- a/user/src/main/resources/application-local.yml
+++ b/user/src/main/resources/application-local.yml
@@ -18,6 +18,12 @@ spring:
 server:
   port: ${USER_SERVER_PORT}
 
+springdoc:
+  api-docs:
+    path: /users/v3/api-docs
+  swagger-ui:
+    path: /users/swagger-ui.html
+
 eureka:
   instance:
     hostname: ${USER_SERVER_HOST}


### PR DESCRIPTION
close #48 

## 구현 내용
### Spring Cloud gateway에 Swagger 설정 적용
- 각 서비스 별로 Swagger를 통합합니다. 아래 사진의 화살표로 바꿀 수 있습니다.
- 기본 url은 `http://localhost:18080/swagger-ui.html` 입니다.
![image](https://github.com/user-attachments/assets/7c45c798-f5a8-4628-8af8-69a97bc9ee7c)
## 중요!
- Order 서버는 아직 Swagger 설정이 미구현 되어 있어, 추후에 아래와 같이 설정을 추가해주세요!
Order 서버의 application.yml
```yml
springdoc:
  api-docs:
    path: /orders/v3/api-docs
  swagger-ui:
    path: /orders/swagger-ui.html
```
- Spring Security에 Swagger path를 permitAll 해도 계속 인증을 필요로 한다길래 일단 anyRequest.permitAll 로 돌려놨습니다..


## 수정 사항
### 각 서비스 별 Swagger Path 커스텀
Spring Cloud Gateway에서 각 서비스 별 Swagger API를 알고있어야 하는데, 모든 서비스가 기본 값을 사용하고 있으면 구분을 못하는 문제가 생겨서 각 서비스 별로 `/서비스명/swagger-ui.html`, `/서비스명/v3/api-docs` 로 통일시켰습니다.

아래 설정에서 urls 부분에 각 서비스별 Swagger path를 설정하게 되는데, 모두 기본 값을 사용하면
각 서비스 url에 `/v3/api-docs` 를 넣게 되고 gateway 입장에서는 경로를 구분하지 못하는 문제가 발생합니다.
```yml
springdoc:
  api-docs:
    enabled: true
  swagger-ui:
    enabled: true
    urls:
      - url: /users/v3/api-docs
        name: User
      - url: /companies/v3/api-docs
        name: Company
      - url: /hubs/v3/api-docs
        name: Hub
      - url: /orders/v3/api-docs
        name: Order
```

