### PR TITLE
Fix: Order 생성 시 에러 catch 통해서 재고 복구 코드 작성

### DIFF
--- a/hub/src/main/java/com/example/hub/presentation/controller/DeliveryManagerController.java
+++ b/hub/src/main/java/com/example/hub/presentation/controller/DeliveryManagerController.java
@@ -4,6 +4,7 @@ import com.example.hub.application.service.DeliveryManagerService;
 import com.example.hub.presentation.request.DeliveryManagerCreateRequest;
 import com.example.hub.presentation.response.CommonResponse;
 import com.example.hub.presentation.response.DeliveryManagerResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,7 +25,7 @@ public class DeliveryManagerController {
     // 배송담당자 생성     (마스터만 가능)
     @PostMapping
     public CommonResponse<DeliveryManagerResponse> createDeliveryManager(
-            @RequestBody DeliveryManagerCreateRequest request,
+            @RequestBody @Valid DeliveryManagerCreateRequest request,
             @RequestHeader(value = "X-UserId", required = true) String userId
     ){
         return CommonResponse.success(deliveryManagerService.createDeliveryManager(request,userId));

--- a/order/src/main/java/com/sparta/ch4/delivery/order/application/service/OrderService.java
+++ b/order/src/main/java/com/sparta/ch4/delivery/order/application/service/OrderService.java
@@ -4,6 +4,7 @@ import com.sparta.ch4.delivery.order.application.dto.DeliveryDto;
 import com.sparta.ch4.delivery.order.application.dto.OrderCreateDto;
 import com.sparta.ch4.delivery.order.application.dto.OrderDto;
 import com.sparta.ch4.delivery.order.domain.exception.ApplicationException;
+import com.sparta.ch4.delivery.order.domain.exception.ErrorCode;
 import com.sparta.ch4.delivery.order.domain.model.Delivery;
 import com.sparta.ch4.delivery.order.domain.model.DeliveryHistory;
 import com.sparta.ch4.delivery.order.domain.model.Order;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.sparta.ch4.delivery.order.domain.exception.ErrorCode.*;
 import static com.sparta.ch4.delivery.order.domain.exception.ErrorCode.COMPANY_CLIENT_ERROR;
 import static com.sparta.ch4.delivery.order.domain.exception.ErrorCode.PRODUCT_INVALID_ARGUMENT;
 
@@ -61,6 +63,9 @@ public class OrderService {
                     orderCreatDto.createdBy()
             );
             List<HubRouteForOrderResponse> hubRoute = hubRouteResponse.getData();
+            if (!hubRoute.isEmpty()){
+                throw new ApplicationException(HUB_CLIENT_ERROR);
+            }
 
             // 3. 수령업체 정보 검증
             CommonResponse<CompanyResponse> companyResponse = companyClient.getCompany(orderCreatDto.receiverId());
@@ -88,8 +93,11 @@ public class OrderService {
             companyClient.updateQuantity(orderCreatDto.productId(), ProductQuantityUpdateRequest.from(orderCreatDto.quantity(), ProductQuantity.UP));
             log.error("주문 생성 실패: ", e);
             throw e;
+        } catch (Exception e){
+            companyClient.updateQuantity(orderCreatDto.productId(), ProductQuantityUpdateRequest.from(orderCreatDto.quantity(), ProductQuantity.UP));
+            log.error("주문 생성 로직 에러: ", e);
+            throw e;
         }
-
     }
 
 

--- a/order/src/main/java/com/sparta/ch4/delivery/order/domain/exception/ErrorCode.java
+++ b/order/src/main/java/com/sparta/ch4/delivery/order/domain/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     DELIVERYMANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 배송담당자를 찾지 못하였습니다."),
     DELIVERYMANAGER_DUPLICATED(HttpStatus.CONFLICT, "해당 배송담당자는 이미 다른 허브에 배정되었습니다"),
     DUPLICATED_HUBNAME(HttpStatus.CONFLICT, "이미 해당 허브가 존재합니다."),
-
+    HUB_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "허브 API 요청에 문제가 있습니다."),
     //Company
     COMPANY_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "업체 API 요청에 문제가 있습니다."),
 


### PR DESCRIPTION
## Fix
- createOrder에서  catch문을 더 추가해 로직 전반의 에러를 핸들링하여 재고 복구
- DeliveryManagerController 의 요청 객체에 `@Valid` 추가

